### PR TITLE
Feature: Support for retrieving multiple result sets

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -1109,6 +1109,20 @@ public:
         return col.sqltype_;
     }
 
+    bool next_result() const
+    {
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            SQLMoreResults
+            , rc
+            , stmt_.native_statement_handle());
+        if (rc == SQL_NO_DATA)
+            return false;
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+        return true;
+    }
+
     template<class T>
     T get(short column) const
     {
@@ -1974,6 +1988,11 @@ string_type result::column_name(short column) const
 int result::column_datatype(short column) const
 {
     return impl_->column_datatype(column);
+}
+
+bool result::next_result() const
+{
+    return impl_->next_result();
 }
 
 template<class T>

--- a/nanodbc.h
+++ b/nanodbc.h
@@ -571,6 +571,9 @@ public:
     //! Returns a identifying integer value representing the C type of this column.
     int column_datatype(short column) const;
 
+    //! Returns the next result
+    bool next_result() const;
+
 private:
     result(statement statement, long rowset_size);
 


### PR DESCRIPTION
Necessary when a stored procedure returns multiple result sets.
Useful for e.g. when combining 2 selects in one round trip to the server (SELECT x FROM x; SELECT y FROM y;)
