### PR TITLE
Feature: Support for retrieving output/return parameters when calling stored procedure

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -891,7 +891,7 @@ public:
     }
 
     template<class T>
-    void bind_parameter(long param, const T* value, long* nulls)
+    void bind_parameter(long param, const T* value, long* nulls, param_direction direction)
     {
         RETCODE rc;
         SQLSMALLINT data_type;
@@ -908,12 +908,31 @@ public:
         if(!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
 
+        SQLSMALLINT        fParamType;
+        switch (direction) {
+            default:
+                assert(false);
+                //fallthrough
+            case In:
+                fParamType = SQL_PARAM_INPUT;
+                break;
+            case Out:
+                fParamType = SQL_PARAM_OUTPUT;
+                break;
+            case InOut:
+                fParamType = SQL_PARAM_INPUT_OUTPUT;
+                break;
+            case Return:
+                fParamType = SQL_PARAM_OUTPUT;
+                break;
+        }
+
         NANODBC_CALL_RC(
             SQLBindParameter
             , rc
             , stmt_
             , param + 1
-            , SQL_PARAM_INPUT
+            , fParamType
             , sql_type_info<T>::ctype
             , data_type
             , parameter_size // column size ignored for many types, but needed for strings
@@ -1835,22 +1854,22 @@ unsigned long statement::parameter_size(long param) const
 }
 
 template<class T>
-void statement::bind_parameter(long param, const T* value, long* nulls)
+void statement::bind_parameter(long param, const T* value, long* nulls, param_direction direction)
 {
-    impl_->bind_parameter(param, reinterpret_cast<const T*>(value), nulls);
+    impl_->bind_parameter(param, reinterpret_cast<const T*>(value), nulls, direction);
 }
 
 // The following are the only supported instantiations of statement::bind_parameter().
-template void statement::bind_parameter(long, const char*, long*);
-template void statement::bind_parameter(long, const short*, long*);
-template void statement::bind_parameter(long, const unsigned short*, long*);
-template void statement::bind_parameter(long, const int32_t*, long*);
-template void statement::bind_parameter(long, const uint32_t*, long*);
-template void statement::bind_parameter(long, const int64_t*, long*);
-template void statement::bind_parameter(long, const uint64_t*, long*);
-template void statement::bind_parameter(long, const float*, long*);
-template void statement::bind_parameter(long, const double*, long*);
-template void statement::bind_parameter(long, const date*, long*);
+template void statement::bind_parameter(long, const char*, long*, param_direction);
+template void statement::bind_parameter(long, const short*, long*, param_direction);
+template void statement::bind_parameter(long, const unsigned short*, long*, param_direction);
+template void statement::bind_parameter(long, const int32_t*, long*, param_direction);
+template void statement::bind_parameter(long, const uint32_t*, long*, param_direction);
+template void statement::bind_parameter(long, const int64_t*, long*, param_direction);
+template void statement::bind_parameter(long, const uint64_t*, long*, param_direction);
+template void statement::bind_parameter(long, const float*, long*, param_direction);
+template void statement::bind_parameter(long, const double*, long*, param_direction);
+template void statement::bind_parameter(long, const date*, long*, param_direction);
 
 } // namespace nanodbc
 

--- a/nanodbc.h
+++ b/nanodbc.h
@@ -340,6 +340,8 @@ public:
     //! \brief Returns the parameter size for the indicated parameter placeholder within a prepared statement.
     unsigned long parameter_size(long param) const;
 
+    enum param_direction { In, Out, InOut, Return };
+
     //! \brief Binds the given value to the given parameter placeholder number in the prepared statement.
     //!
     //! If your prepared SQL query has any ? placeholders, this is how you bind values to them.
@@ -350,7 +352,7 @@ public:
     //! \param nulls Used to batch insert nulls into the database.
     //! \throws database_error
     template<class T>
-    void bind_parameter(long param, const T* value, long* nulls = 0);
+    void bind_parameter(long param, const T* value, long* nulls = 0, param_direction direction = In);
 
     //! \brief Binds the given values to the given parameter placeholder number in the prepared statement.
     //!


### PR DESCRIPTION
...dures.  You need to retrieve all returned result sets before the output parameters are filled in (using next_result(), provided by separate commit).

Example:
nanodbc::statement stmt(conn);
stmt.prepare(conn, "{? = CALL dbo.spMyProc(?,?,?)}");
stmt.bind_parameter(0, &result, NULL, nanodbc::statement::Return);
stmt.bind_parameter(1, str.c_str());
stmt.bind_parameter(2, &i);
stmt.bind_parameter(3, &j, nanodbc::statement::Out);
nanodbc::result resultset = stmt.execute();
while (resultset.next_result()) ;
conn.disconnect();
