### PR TITLE
Added 64-bit support

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -366,7 +366,7 @@ namespace
         SQLULEN clen_;
         bool blob_;
         long rowset_size_;
-        long* cbdata_;
+        nanodbc::null_type* cbdata_;
         char* pdata_;
 
     private:
@@ -912,7 +912,7 @@ public:
     }
 
     template<class T>
-    void bind_parameter(long param, const T* value, long* nulls, param_direction direction)
+    void bind_parameter(long param, const T* value, null_type* nulls, param_direction direction)
     {
         RETCODE rc;
         SQLSMALLINT data_type;
@@ -1335,7 +1335,7 @@ private:
         for(SQLSMALLINT i = 0; i < n_columns; ++i)
         {
             bound_column& col = bound_columns_[i];
-            col.cbdata_ = new long[rowset_size_];
+            col.cbdata_ = new null_type[rowset_size_];
             if(col.blob_)
             {
                 NANODBC_CALL_RC(
@@ -1890,22 +1890,22 @@ unsigned long statement::parameter_size(long param) const
 }
 
 template<class T>
-void statement::bind_parameter(long param, const T* value, long* nulls, param_direction direction)
+void statement::bind_parameter(long param, const T* value, null_type* nulls, param_direction direction)
 {
     impl_->bind_parameter(param, reinterpret_cast<const T*>(value), nulls, direction);
 }
 
 // The following are the only supported instantiations of statement::bind_parameter().
-template void statement::bind_parameter(long, const char*, long*, param_direction);
-template void statement::bind_parameter(long, const short*, long*, param_direction);
-template void statement::bind_parameter(long, const unsigned short*, long*, param_direction);
-template void statement::bind_parameter(long, const int32_t*, long*, param_direction);
-template void statement::bind_parameter(long, const uint32_t*, long*, param_direction);
-template void statement::bind_parameter(long, const int64_t*, long*, param_direction);
-template void statement::bind_parameter(long, const uint64_t*, long*, param_direction);
-template void statement::bind_parameter(long, const float*, long*, param_direction);
-template void statement::bind_parameter(long, const double*, long*, param_direction);
-template void statement::bind_parameter(long, const date*, long*, param_direction);
+template void statement::bind_parameter(long, const char*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const short*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const unsigned short*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const int32_t*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const uint32_t*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const int64_t*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const uint64_t*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const float*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const double*, nanodbc::null_type*, param_direction);
+template void statement::bind_parameter(long, const date*, nanodbc::null_type*, param_direction);
 
 } // namespace nanodbc
 

--- a/nanodbc.h
+++ b/nanodbc.h
@@ -99,9 +99,20 @@ namespace nanodbc
     #else
         typedef std::string string_type;
     #endif // NANODBC_USE_UNICODE
+
+    #if defined(_WIN64) || defined(__LP64__)
+        // LLP64 machine, Windows
+        // LP64 machine, OS X or Linux
+        typedef __int64 null_type;
+    #else
+        // 32-bit machine, Windows or Linux or OS X
+        typedef long null_type;
+    #endif
 #else
     //! string_type will be std::wstring if NANODBC_USE_UNICODE is defined, otherwise std::string.
     typedef unspecified-type string_type;
+    //! null_type will be __int64 for 64-bit compilations, otherwise long.
+    typedef unspecified-type null_type;
 #endif // DOXYGEN
 
 //! \addtogroup exceptions Exception Types
@@ -372,7 +383,7 @@ public:
     //! \param nulls Used to batch insert nulls into the database.
     //! \throws database_error
     template<class T>
-    void bind_parameter(long param, const T* value, long* nulls = 0, param_direction direction = PARAM_IN);
+    void bind_parameter(long param, const T* value, null_type* nulls = 0, param_direction direction = PARAM_IN);
 
     //! \brief Binds the given values to the given parameter placeholder number in the prepared statement.
     //!


### PR DESCRIPTION
The "long *" pointers (which specify whether or not parameter values are NULL) resulted in compiler errors when using x64 compilation on VC8.  The odbc API expects a SQLLEN which is __int64 on x64 compilations.

To fix this, in nanodbc, I replaced the long with a new null_type that is long on 32-bit, and __int64 on 64-bit.
