### PR TITLE
Change std::snprintf to _snprintf for VC11

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -62,7 +62,7 @@
     #else
         #define NANODBC_TEXT(s) s
         #define NANODBC_SSCANF std::sscanf
-        #define NANODBC_SNPRINTF std::snprintf
+        #define NANODBC_SNPRINTF _snprintf
         #define NANODBC_STRFTIME std::strftime
         #define NANODBC_STRLEN std::strlen
         #define NANODBC_UNICODE(f) f


### PR DESCRIPTION
Building on VC11 in multi-byte character mode failed with an error about std:: not containing snprintf. Changing this line to match the unicode version a few lines above it fixed the issue.
