### PR TITLE
auto_bind corrections, additional warning suppression

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -10,10 +10,11 @@
 #include <ctime>
 #include <map>
 
-#if defined(_MSC_VER) && _MSC_VER <= 1500
+#if defined(_MSC_VER) && _MSC_VER <= 1600
     // silence spurious Visual C++ 2005 warnings 
     #pragma warning(disable:4244)
     #pragma warning(disable:4312)
+	#pragma warning(disable:4996)
 #endif
 
 #ifdef __APPLE__
@@ -1611,13 +1612,13 @@ private:
                 case SQL_CHAR:
                 case SQL_VARCHAR:
                     col.ctype_ = SQL_C_CHAR;
-                    col.clen_ = col.sqlsize_ + sizeof(NANODBC_SQLCHAR);
-                    break;
+                    col.clen_ = ( col.sqlsize_ + 1 ) * sizeof(SQLCHAR);
+					break;
                 case SQL_WCHAR:
                 case SQL_WVARCHAR:
                     col.ctype_ = SQL_C_WCHAR;
-                    col.clen_ = col.sqlsize_ + sizeof(NANODBC_SQLCHAR);
-                    break;
+                    col.clen_ = ( col.sqlsize_ + 1 ) * sizeof(SQLWCHAR);
+					break;
                 case SQL_LONGVARCHAR:
                     col.ctype_ = SQL_C_CHAR;
                     col.blob_ = true;


### PR DESCRIPTION
I think this is a bug fix I offered up before, but I got focused on other things and didn't get it done.

First, I added an additional disabled warning (4996, about _snprintf), and bumped up the version to _MSC_VER <= 1600, so Visual C++ 2010 would benefit from it. I still have to use that old clunky version.

Now the big one:, in auto_bind, the character data needs to be allocated in _SQL_ data sizes. So SQL_CHAR needs to be size SQLCHAR, even if you're ultimately going to Unicode, since you're setting col.ctype_ = SQL_C_CHAR. Likewise, for SQL_WCHAR, the size needs to be SQLWCHAR, since col.ctype_ = SQL_C_WCHAR.

The way you had it before, you weren't allocating enough space for SQLWCHAR data, and therefore string data was getting overlaid on top of each other, corrupting the results.

Now, I _think_ you could do it another way, if you wanted, and let SQL do all the translation. To do that, you would actually do something like this, I think. 

```
case SQL_CHAR:
case SQL_VARCHAR:
case SQL_WCHAR:
case SQL_WVARCHAR:
    #ifdef NANODBC_USE_UNICODE
        col.ctype_ = SQL_C_WCHAR;
    #else
        col.ctype_ = SQL_C_CHAR;
    #endif
    col.clen_ = ( col.sqlsize_ + 1 ) * sizeof(NANODBC_SQLCHAR);
```

I don't know this for sure; I haven't tried it! I might though. If I do I'll let you know. The disadvantage here is that you're committing to one string type in your code at compile time. In theory, your current setup, combined with my pull request, lets you mix and match narrow and wide char strings in the same application, as you choose.
