### PR TITLE
VS2013 and later: set NANODBC_USE_CPP11, silence warnings

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -10,13 +10,13 @@
 #include <ctime>
 #include <map>
 
-#ifdef NANODBC_USE_CPP11
+#if defined(NANODBC_USE_CPP11)
     #include <cstdint>
 #else
     #include <stdint.h> // assuming we have C99 intmax_t
 #endif
 
-#if defined(_MSC_VER) && _MSC_VER <= 1600
+#if defined(_MSC_VER) && _MSC_VER <= 1800
     // silence spurious Visual C++ warnings 
     #pragma warning(disable:4244) // warning about integer conversion issues.
     #pragma warning(disable:4312) // warning about 64-bit portability issues.

--- a/nanodbc.h
+++ b/nanodbc.h
@@ -77,6 +77,10 @@
 #include <string>
 #include <vector>
 
+#if !defined(NANODBC_USE_CPP11) && defined(_MSC_VER) && _MSC_VER >= 1800
+#define NANODBC_USE_CPP11
+#endif
+
 // Define NANODBC_HAS_TR1_NAMESPACE if your compiler's standard library implementation
 // has a std::tr1 namespace, otherwise we try to detect automatically.
 #ifndef NANODBC_HAS_TR1_NAMESPACE


### PR DESCRIPTION
Visual Studio 2013 works great with the NANODBC_USE_CPP11 flag. Why not make that automatic? It still, however, requires the silencing of various warnings in nanodbc.cpp.
