### PR TITLE
Fixed incorrect columns with multiple result sets

### DIFF
--- a/nanodbc.h
+++ b/nanodbc.h
@@ -926,7 +926,7 @@ public:
     int column_datatype(const string_type& column_name) const;
 
     //! Returns the next result, for example when stored procedure returns multiple result sets.
-    bool next_result() const;
+    bool next_result();
 
     #ifndef DOXYGEN
         #ifdef NANODBC_USE_CPP11


### PR DESCRIPTION
I found that the current multiple result set handling expected every result set to consist of the same columns so I changed it to rebind the columns for every result set to support different columns in each result set.

I have tested this on linux and windows against MSSQL, but did not see an easy way to write unit tests for this against SQLite.  If you have any ideas please let me know and I will add some tests.
