### PR TITLE
Added support for SQLProcedureColumns

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -1131,6 +1131,36 @@ public:
         return result(statement, batch_operations);
     }
 
+    result procedure_columns(
+        const string_type& catalog
+        , const string_type& schema
+        , const string_type& procedure
+        , const string_type& column
+        , statement& statement)
+    {
+        if(!open())
+            throw programming_error("statement has no associated open connection");
+        
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            NANODBC_UNICODE(SQLProcedureColumns)
+            , rc
+            , stmt_
+            , (NANODBC_SQLCHAR*)(catalog.empty() ? NULL : catalog.c_str())
+            , (catalog.empty() ? 0 : SQL_NTS)
+            , (NANODBC_SQLCHAR*)(schema.empty() ? NULL : schema.c_str())
+            , (schema.empty() ? 0 : SQL_NTS)
+            , (NANODBC_SQLCHAR*)procedure.c_str()
+            , SQL_NTS
+            , (NANODBC_SQLCHAR*)(column.empty() ? NULL : column.c_str())
+            , (column.empty() ? 0 : SQL_NTS));
+
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
+
+        return result(statement, 1);
+    }
+    
     long affected_rows() const
     {
         SQLLEN rows;
@@ -2507,6 +2537,15 @@ result statement::execute_direct(
 result statement::execute(long batch_operations, long timeout)
 {
     return impl_->execute(batch_operations, timeout, *this);
+}
+
+result statement::procedure_columns(
+    const string_type& catalog
+    , const string_type& schema
+    , const string_type& procedure
+    , const string_type& column)
+{
+    return impl_->procedure_columns(catalog, schema, procedure, column, *this);
 }
 
 long statement::affected_rows() const

--- a/nanodbc.h
+++ b/nanodbc.h
@@ -438,6 +438,15 @@ public:
     //! \see open(), prepare(), execute(), result, transaction
     class result execute(long batch_operations = 1, long timeout = 0);
 
+    //! \brief Returns the input and output paramters of the specified stored procedure.
+    //! \param catalog The catalog name of the procedure.
+    //! \param schema Pattern to use for schema names.
+    //! \param procedure The name of the procedure.
+    //! \param column Pattern to use for column names.
+    //! \throws database_error
+    //! \return A result set object.
+    class result procedure_columns(const string_type& catalog, const string_type& schema, const string_type& procedure, const string_type& column);
+    
     //! \brief Returns the number of rows affected by the request or -1 if the number of affected rows is not available.
     //! \throws database_error
     long affected_rows() const;


### PR DESCRIPTION
This change adds support for the SQLProcedureColumns function.  I have testing on linux and windows against MSSQL, but I don't see an easy way to write unit tests since sqlite doesn't support stored procedures.
