### PR TITLE
don't throw exception when failing to set default timeout on stmt

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -1045,7 +1045,10 @@ public:
             , SQL_ATTR_QUERY_TIMEOUT
             , (SQLPOINTER)timeout,
              0);
-        if(!success(rc))
+
+        // some drivers don't support timeout for statements,
+        // so only raise the error if a non-default timeout was requested.
+        if(!success(rc) && (timeout != 0))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
     }
 


### PR DESCRIPTION
Some ODBC drivers (e.g. Microsoft Access on Windows) do not support setting a query timeout on a statement (SQL_ATTR_QUERY_TIMEOUT). This change prevents an exception being raised when an error code is returned from attempting to set a timeout of 0 (the default timeout value).