### PR TITLE
Enable support for nvarchar(max) and varchar(max) with SQL Server Native Client ODBC driver

### DIFF
--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <ctime>
 #include <map>
+#include <sstream>
 
 #if defined(NANODBC_USE_CPP11)
     #include <codecvt>
@@ -28,7 +29,7 @@
 #if defined(_MSC_VER) && _MSC_VER <= 1800
     // silence spurious Visual C++ warnings
     #pragma warning(disable:4244) // warning about integer conversion issues.
-    #pragma warning(disable:4312) // warning about 64-bit portability issues.
+    //#pragma warning(disable:4312) // warning about 64-bit portability issues.
     #pragma warning(disable:4996) // warning about snprintf() deprecated.
 #endif
 
@@ -39,6 +40,7 @@
 
 #ifdef _WIN32
     // needs to be included above sql.h for windows
+    #define NOMINMAX
     #include <windows.h>
 #endif
 
@@ -192,6 +194,42 @@ namespace
             return s;
         }
     #endif
+
+        inline void convert(const std::string& in, std::wstring & out);
+        inline void convert(const std::wstring& in, std::string & out);
+
+    #if defined(NANODBC_USE_CPP11)
+        // Convert std::string to std::wstring
+        inline void convert(const std::string& in, std::wstring & out)
+        {
+            std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+            out = conv.from_bytes(in);
+        }
+
+        // Convert std::wstring to std::string
+        inline void convert(const std::wstring& in, std::string & out)
+        {
+            std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+            out = conv.to_bytes(in);
+        }
+    #else
+        #error Not implemented (use utf8 library)
+    #endif
+
+        // Courtesy method to avoid #if defined(NANODBC_USE_UNICODE) 
+        // all over the place
+        inline void convert(const std::string& in, std::string & out)
+        {
+            out = in;
+        }
+
+        // Courtesy method to avoid #if defined(NANODBC_USE_UNICODE)
+        // all over the place
+        inline void convert(const std::wstring& in, std::wstring & out)
+        {
+            out = in;
+        }
+
 
     // Attempts to get the most recent ODBC error as a string.
     inline std::string recent_error(SQLHANDLE handle, SQLSMALLINT handle_type)
@@ -1899,6 +1937,24 @@ private:
             if(!success(rc))
                 NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
 
+            // Adjust the sqlsize parameter in case of "unlimited" data (varchar(max), nvarchar(max)).
+            bool isBlob = false;
+
+            if (sqlsize == 0)
+            {
+                switch (sqltype)
+                {
+                    case SQL_VARCHAR:
+                    case SQL_WVARCHAR:
+                    {
+                        //// Divide in half, due to sqlsize being 32-bit in Win32 (and 64-bit in x64)
+                        //sqlsize = std::numeric_limits<int32_t>::max() / 2 - 1;
+                        isBlob = true;
+                    }
+
+                }
+            }
+
             bound_column& col = bound_columns_[i];
             col.name_ = reinterpret_cast<string_type::value_type*>(column_name);
             col.column_ = i;
@@ -1943,11 +1999,21 @@ private:
                 case SQL_VARCHAR:
                     col.ctype_ = SQL_C_CHAR;
                     col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
+                    if (isBlob)
+                    {
+                        col.clen_ = 0;
+                        col.blob_ = true;
+                    }
                     break;
                 case SQL_WCHAR:
                 case SQL_WVARCHAR:
                     col.ctype_ = SQL_C_WCHAR;
                     col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
+                    if (isBlob)
+                    {
+                        col.clen_ = 0;
+                        col.blob_ = true;
+                    }
                     break;
                 case SQL_LONGVARCHAR:
                     col.ctype_ = SQL_C_CHAR;
@@ -2102,13 +2168,62 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
         case SQL_C_WCHAR:
         {
-            if(col.blob_)
-                throw std::runtime_error("CLOB/BLOB not implemented yet for wide char types");
-            const SQLWCHAR* s =
-                reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
-            const string_type::size_type str_size = *col.cbdata_ / sizeof(SQLWCHAR);
-            // TODO: convert() if string_type::value_type is not SQLWCHAR
-            result.assign(s, s + str_size);
+            if (col.blob_)                
+            {
+                // Input is always std::wstring, output might be std::string or std::wstring.
+                // Use a string builder to build the output string.
+                wstringstream ss;
+                wchar_t buffer[512] = { 0 };
+
+                std::size_t buffer_size = sizeof(buffer);
+                SQLLEN ValueLenOrInd;
+                SQLRETURN rc;
+                void* handle = native_statement_handle();
+                do
+                {
+                    NANODBC_CALL_RC(
+                        SQLGetData
+                        , rc
+                        , handle            // StatementHandle
+                        , column + 1        // Col_or_Param_Num
+                        , SQL_C_WCHAR        // TargetType
+                        , buffer              // TargetValuePtr
+                        , buffer_size         // BufferLength
+                        , &ValueLenOrInd);  // StrLen_or_IndPtr
+                    if (ValueLenOrInd > 0)
+                    {
+                        //result.append(buff);
+                        ss << buffer;
+                    }
+                } while (rc > 0);
+
+
+                // Run the wstring through the converter (if necessary)
+                convert(ss.str(), result);
+            }
+            else
+            {
+                // Type is unicode in the database, convert if necessary
+                const SQLWCHAR* s =
+                    reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
+                const string_type::size_type str_size = *col.cbdata_ / sizeof(SQLWCHAR);
+
+                #ifdef NANODBC_USE_CPP11
+                #ifdef NANODBC_USE_UNICODE
+                    // TODO: convert() if string_type::value_type is not SQLWCHAR
+                    // From Unicode to Unicode
+                    result.assign(s, s + str_size);
+
+                #else
+                    // From Unicode to ASCII
+                    std::wstring tempResult(s, s + str_size);
+                    convert(tempResult, result);
+                #endif
+                #else
+                    #error Not implemented for non-CPP11
+                #endif
+            }
+
             return;
         }
 

--- a/nanodbc.cpp
+++ b/nanodbc.cpp
@@ -29,7 +29,7 @@
 #if defined(_MSC_VER) && _MSC_VER <= 1800
     // silence spurious Visual C++ warnings
     #pragma warning(disable:4244) // warning about integer conversion issues.
-    //#pragma warning(disable:4312) // warning about 64-bit portability issues.
+    #pragma warning(disable:4312) // warning about 64-bit portability issues.
     #pragma warning(disable:4996) // warning about snprintf() deprecated.
 #endif
 
@@ -1281,7 +1281,8 @@ public:
                 return SQL_PARAM_OUTPUT;
                 break;
         }
-        assert(false);
+        // Remove warning C4702 : unreachable code nanodbc.cpp 1284	Nanodbc
+        //assert(false);
     }
 
     // initializes bind_len_or_null_ and gets information for bind
@@ -1324,7 +1325,7 @@ public:
     void bind_parameter(
         short param
         , const T* data
-        , std::size_t elements
+        , std::size_t /*elements*/
         , SQLSMALLINT data_type
         , SQLSMALLINT param_type
         , SQLULEN parameter_size)
@@ -1356,7 +1357,7 @@ public:
     void bind_strings(
         short param
         , const string_type::value_type* values
-        , std::size_t length
+        , std::size_t /*length*/
         , std::size_t elements
         , param_direction direction)
     {
@@ -2138,7 +2139,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
             {
                 // Input is always std::string, while output may be std::string or std::wstring
                 stringstream ss;
-				char buff[1024] = {0};
+                char buff[1024] = {0};
                 std::size_t buff_size = sizeof(buff);
 
                 SQLLEN ValueLenOrInd;
@@ -2158,13 +2159,13 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
                     if(ValueLenOrInd > 0)
                     {
-						ss << buff;
-						//result.append(buff);
-					}
+                        ss << buff;
+                        //result.append(buff);
+                    }
                 } while(rc > 0);
 
-				// Run the string through the converter (if necessary)
-				convert(ss.str(), result);
+                // Run the string through the converter (if necessary)
+                convert(ss.str(), result);
             }
             else
             {
@@ -2217,9 +2218,9 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
                 const string_type::size_type str_size = *col.cbdata_ / sizeof(SQLWCHAR);
 
-				std::wstring tempResult(s, s + str_size);
+                std::wstring tempResult(s, s + str_size);
 
-				convert(tempResult, result);
+                convert(tempResult, result);
 
             }
 


### PR DESCRIPTION
Hi,

I had a problem with getting any data from a database field where the type was either `varchar(max)` or `nvarchar(max)`, no matter what I tried, it always returned an empty string.

I traced the problem to `auto_bind()`, namely the ODBC call `SQLDescribeCol`.

In my case, the `sqlsize` was 0 for those types. According to the docs, the size could then be between 0 and 2^31-1 bytes.

What worked for me was hooking into the half-done blob functionality, and finish those for the types I use.

As a bonus; I fixed some other compilation issues with C++11 and Unicode and some of the TODOs in the code.

I've tried to adhere to the code style already used, and this works for me. I have only tested this with Win32 and Win64 builds with C++11, non-Unicode and with Unicode. Unfortunately, I haven't been able to test with GCC.

Here is a test case proving the not working broken, and working version working:

```cpp
#include <iostream>
#include <nanodbc.h>

#ifdef NANODBC_USE_UNICODE
# define UNI(a) L ## a
#else
# define UNI(a) a
#endif



int main()
{
	typedef nanodbc::string_type str;

#ifdef NANODBC_USE_UNICODE
	str encoding = UNI("Unicode");
	auto & out = std::wcout;
#else
	str encoding = UNI("Ascii");
	auto & out = std::cout;
#endif


	try
	{
		// Standard output device

		str dsn  = UNI("nanobug");
		str user = UNI("");
		str pass = UNI("");

		nanodbc::connection nanoConnection(dsn, user, pass);

		if (nanoConnection.connected())
		{

			out << UNI("Connected with driver ") << nanoConnection.driver_name() << " with encoding " << encoding << std::endl ;

			std::vector<str> statements
			{
				UNI("DROP DATABASE [nanobug];"),
				UNI("CREATE DATABASE [nanobug];"),
				UNI("USE [nanobug];"),
				UNI("IF OBJECT_ID('simple_test', 'U') IS NOT NULL DROP TABLE simple_test;"),
				UNI("create table simple_test (id int, limited varchar(10), unilimited nvarchar(10), val varchar(max), uni nvarchar(max));"),
				UNI("insert into simple_test values (1, 'one', 'one', 'one', 'one');"),
				UNI("insert into simple_test values (2, 'two', 'two', 'two', 'two');"),
				UNI("insert into simple_test values (3, 'three', 'three', 'three', 'three');")
			};

			for (const auto & stmt : statements)
			{
				out << stmt << std::endl;
				auto result = execute(nanoConnection, stmt);
			}

			str query = UNI("select id, limited, unilimited, val, uni from simple_test");

			nanodbc::statement statement(nanoConnection, query);
			nanodbc::result nanoresults = statement.execute();

			while(nanoresults.next())
			{
				auto id			= nanoresults.get<int>(UNI("id"));
				auto limited	= nanoresults.get<str>(UNI("limited"));
				auto unilimited	= nanoresults.get<str>(UNI("unilimited"));
				auto val		= nanoresults.get<str>(UNI("val"));
				auto uni		= nanoresults.get<str>(UNI("uni"));

				out << 
					UNI("Id: '") << id << 
					UNI("' limited: '") << limited << 
					UNI("' unicode limited: '") << unilimited << 
					UNI("' val: '") << val << 
					UNI("' unicode: '") << uni << UNI("'") 
					<< std::endl;
			}


			int a_mighty_fine_place_to_break=0;
		}

	}
	catch (const std::exception & ex)
	{
		std::cout << ex.what();
	}


	return 0;
}
```

Correct output should be:

```
Connected with driver sqlncli11.dll with encoding Ascii
DROP DATABASE [nanobug];
CREATE DATABASE [nanobug];
USE [nanobug];
IF OBJECT_ID('simple_test', 'U') IS NOT NULL DROP TABLE simple_test;
create table simple_test (id int, limited varchar(10), unilimited nvarchar(10), val varchar(max), uni nvarchar(max));
insert into simple_test values (1, 'one', 'one', 'one', 'one');
insert into simple_test values (2, 'two', 'two', 'two', 'two');
insert into simple_test values (3, 'three', 'three', 'three', 'three');
Id: '1' limited: 'one' unicode limited: 'one' val: 'one' unicode: 'one'
Id: '2' limited: 'two' unicode limited: 'two' val: 'two' unicode: 'two'
Id: '3' limited: 'three' unicode limited: 'three' val: 'three' unicode: 'three'
```

For incorrect output, the `val` and `unicode` values are either empty or full of garbage.

I'm sorry if this will break C++98, I haven't had the capacity to test with a non-C++11 compiler.