### PR TITLE
CMake: fix ODBC linking on Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,17 +42,23 @@ endif()
 ## find unixODBC or iODBC config binary
 ########################################
 if (UNIX)
-	find_program(ODBC_CONFIG odbc_config $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
-
-	if(NOT ODBC_CONFIG)
-		find_program(ODBC_CONFIG iodbc-config $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+	find_program(ODBC_CONFIG odbc_config
+		$ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+	if(ODBC_CONFIG)
+		set(ODBCLIB odbc)
+		set(ODBCINSTLIB odbcinst)
+  else()
+		find_program(ODBC_CONFIG iodbc-config
+			$ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+		if(ODBC_CONFIG)
+			set(ODBCLIB iodbc)
+			set(ODBCINSTLIB iodbcinst)
+		endif()
 	endif()
 
 	if(NOT ODBC_CONFIG)
 		message(FATAL_ERROR "can not find odbc config program")
 	endif()
-elseif(MSVC)
-	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
 endif()
 
 ########################################
@@ -99,9 +105,9 @@ endif()
 ## get ODBC compile and link flags
 ########################################
 if (UNIX)
-	execute_process(COMMAND ${ODBC_CONFIG} --libs OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	execute_process(COMMAND ${ODBC_CONFIG} --cflags OUTPUT_VARIABLE ODBC_COMPILE_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
+	set(ODBC_LIBRARIES ${ODBCLIB} ${ODBCLIBINST})
+elseif(MSVC)
+	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
 endif()
 
 ########################################
@@ -112,10 +118,6 @@ if(Boost_FOUND)
 	link_directories(${CMAKE_BINARY_DIR}/lib ${Boost_LIBRARY_DIRS})
 endif()
 add_library(nanodbc SHARED src/nanodbc.cpp)
-set_target_properties(nanodbc PROPERTIES
-	COMPILE_FLAGS "${ODBC_COMPILE_FLAGS}"
-	LIBRARY_OUTPUT_DIRECTORY "lib"
-)
 target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
 
 if (NANODBC_INSTALL)
@@ -136,8 +138,7 @@ if (NANODBC_TEST)
 	add_custom_target(check
 		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure
 		DEPENDS tests)
-		message(STATUS "Target test: Enabled")
-	else()
-		message(STATUS "Target test: Turned off")
-
+	message(STATUS "Target test: Enabled")
+else()
+	message(STATUS "Target test: Turned off")
 endif()


### PR DESCRIPTION
CMake does not guarantee correctly ordered -L and -l flags
if inserted via LINK_FLAGS property.
Fix linking error by passing ODBC libraries via recommended
taret_link_libraries macro.
Bug and fix confirmed on Ubuntu 12.04 with GCC 5.x.