### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: false
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-5
+      - gcc-5
+      - libboost-dev
+      - libboost-test-dev
+      - libiodbc2
+      - libiodbc2-dev
+      - libsqliteodbc
+
+language: cpp
+
+compiler:
+  - gcc
+
+before_script:
+  - if [ "$CC" == "gcc" ]; then export CC="gcc-5"; fi
+  - if [ "$CXX" == "g++" ]; then export CXX="g++-5"; fi
+  - cat /etc/odbc.ini
+
+script:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make VERBOSE=1
+  - make VERBOSE=1 tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,17 +42,23 @@ endif()
 ## find unixODBC or iODBC config binary
 ########################################
 if (UNIX)
-	find_program(ODBC_CONFIG odbc_config $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
-
-	if(NOT ODBC_CONFIG)
-		find_program(ODBC_CONFIG iodbc-config $ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+	find_program(ODBC_CONFIG odbc_config
+		$ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+	if(ODBC_CONFIG)
+		set(ODBCLIB odbc)
+		set(ODBCINSTLIB odbcinst)
+  else()
+		find_program(ODBC_CONFIG iodbc-config
+			$ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
+		if(ODBC_CONFIG)
+			set(ODBCLIB iodbc)
+			set(ODBCINSTLIB iodbcinst)
+		endif()
 	endif()
 
 	if(NOT ODBC_CONFIG)
 		message(FATAL_ERROR "can not find odbc config program")
 	endif()
-elseif(MSVC)
-	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
 endif()
 
 ########################################
@@ -99,9 +105,9 @@ endif()
 ## get ODBC compile and link flags
 ########################################
 if (UNIX)
-	execute_process(COMMAND ${ODBC_CONFIG} --libs OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	execute_process(COMMAND ${ODBC_CONFIG} --cflags OUTPUT_VARIABLE ODBC_COMPILE_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
+	set(ODBC_LIBRARIES ${ODBCLIB} ${ODBCLIBINST})
+elseif(MSVC)
+	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
 endif()
 
 ########################################
@@ -112,10 +118,6 @@ if(Boost_FOUND)
 	link_directories(${CMAKE_BINARY_DIR}/lib ${Boost_LIBRARY_DIRS})
 endif()
 add_library(nanodbc SHARED src/nanodbc.cpp)
-set_target_properties(nanodbc PROPERTIES
-	COMPILE_FLAGS "${ODBC_COMPILE_FLAGS}"
-	LIBRARY_OUTPUT_DIRECTORY "lib"
-)
 target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
 
 if (NANODBC_INSTALL)
@@ -136,8 +138,7 @@ if (NANODBC_TEST)
 	add_custom_target(check
 		COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure
 		DEPENDS tests)
-		message(STATUS "Target test: Enabled")
-	else()
-		message(STATUS "Target test: Turned off")
-
+	message(STATUS "Target test: Enabled")
+else()
+	message(STATUS "Target test: Turned off")
 endif()


### PR DESCRIPTION
Configures CI builds on Travis CI to build the two targets.
@lexicalunit in order to complete the set up, you need to flip the switch for this repo on Travis CI profile (see step 2. here https://docs.travis-ci.com/user/getting-started/).

* Sample of successfull build: https://travis-ci.org/mloskot/nanodbc/builds/92810326
* TODO: add tests run

NOTE: This PR depends on PR #60.

