### PR TITLE
Refine assert in result_impl::position with SQL_ROW_NUMBER_UNKNOWN

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1932,7 +1932,8 @@ public:
         if(!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
 
-        NANODBC_ASSERT(pos - 1 + rowset_position_ <= static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
+        NANODBC_ASSERT(pos == SQL_ROW_NUMBER_UNKNOWN
+            || pos - 1 + rowset_position_ <= static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
         return static_cast<unsigned long>(pos) - 1 + rowset_position_;
     }
 

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1932,7 +1932,7 @@ public:
         if(!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
 
-        NANODBC_ASSERT(pos == SQL_ROW_NUMBER_UNKNOWN
+        NANODBC_ASSERT(pos == static_cast<SQLULEN>(SQL_ROW_NUMBER_UNKNOWN)
             || pos - 1 + rowset_position_ <= static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));
         return static_cast<unsigned long>(pos) - 1 + rowset_position_;
     }


### PR DESCRIPTION
Apparently, not all drivers support `SQLGetStmtAttr` query for `SQL_ATTR_ROW_NUMBER` or there may be differences in behaviour.
For example, SQLiteODBC driver reports `SQL_ROW_NUMBER_UNKNOWN(-2)` which needs to be taken into account in the assertion.

NOTE: Behaviour of the position() function has not changed.
But, it may be sensible to check if `SQL_ROW_NUMBER_UNKNOWN` is returned, then use it as `position()` return value.
Currently, in such case, the function returns arguable value: `SQL_ROW_NUMBER_UNKNOWN - 1 + rowset_position_`.

See my SO question where I asked about implementation differences (I have checked their code) between various drivers: SQLite3, PostgreSQL, MySQL:
[SQLGetStmtAttr output value for SQL_ATTR_ROW_NUMBER](http://stackoverflow.com/q/33940294/151641)

Also, check in `basic_test::simple_test` might need refinements:
```
BOOST_CHECK(results.position());
```

All of the above has been reproduced and tested on Windows 10 using Visual Studio 2015 + SQLite ODBC driver 32-bit and 64-bit, building the library for both platforms, 32-bit and 64-bit.