### PR TITLE
Fixes cmake build on OS X El Capitan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,12 @@ if(UNIX)
 		message(STATUS "ODBC: unixODBC")
 		set(ODBCLIB odbc)
 		set(ODBCINSTLIB odbcinst)
+		execute_process(COMMAND ${ODBC_CONFIG} --include-prefix
+			OUTPUT_VARIABLE ODBC_INCLUDE_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+		set(ODBC_CFLAGS "-I${ODBC_INCLUDE_DIR}")
+		set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
+		execute_process(COMMAND ${ODBC_CONFIG} --libs
+			OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
 	else()
 		find_program(ODBC_CONFIG iodbc-config
 			$ENV{ODBC_PATH}/bin /usr/bin /usr/local/bin PATHS)
@@ -62,12 +68,20 @@ if(UNIX)
 			message(STATUS "ODBC: iODBC")
 			set(ODBCLIB iodbc)
 			set(ODBCINSTLIB iodbcinst)
+			execute_process(COMMAND ${ODBC_CONFIG} --cflags
+				OUTPUT_VARIABLE ODBC_CFLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+			set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
+			execute_process(COMMAND ${ODBC_CONFIG} --libs
+				OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
 		endif()
 	endif()
 
 	if(NOT ODBC_CONFIG)
 		message(FATAL_ERROR "can not find odbc config program")
 	endif()
+
+	message(STATUS "ODBC compile flags: ${ODBC_CFLAGS}")
+	message(STATUS "ODBC link flags: ${ODBC_LINK_FLAGS}")
 endif()
 
 ########################################
@@ -121,6 +135,7 @@ endif()
 ########################################
 if(UNIX)
 	set(ODBC_LIBRARIES ${ODBCLIB} ${ODBCLIBINST})
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ODBC_LINK_FLAGS}")
 elseif(MSVC)
 	set(ODBC_LIBRARIES odbc32.lib odbccp32.lib Ws2_32.lib)
 endif()
@@ -135,6 +150,12 @@ else()
 	add_library(nanodbc SHARED src/nanodbc.cpp src/nanodbc.h)
 	target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
 	message(STATUS "Build target: SHARED")
+endif()
+
+if(UNIX)
+	set_target_properties(nanodbc PROPERTIES
+		COMPILE_FLAGS "${ODBC_CFLAGS}"
+		LIBRARY_OUTPUT_DIRECTORY "lib")
 endif()
 
 if(NANODBC_INSTALL)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synopsis
 
-[![Build Status](https://travis-ci.org/lexicalunit/nanodbc.svg?branch=master)](https://travis-ci.org/lexicalunit/nanodbc)
+\[ master [![Master Build Status](https://travis-ci.org/lexicalunit/nanodbc.svg?branch=master)](https://travis-ci.org/lexicalunit/nanodbc) \]\[ release [![Release Build Status](https://travis-ci.org/lexicalunit/nanodbc.svg?branch=master)](https://travis-ci.org/lexicalunit/nanodbc) \]
 
 A small C++ wrapper for the native C ODBC API. Please see the [online documentation](http://lexicalunit.github.com/nanodbc/) for user information, example usage, propaganda, and detailed source level documentation.
 
@@ -19,11 +19,11 @@ Nanodbc is intentionally small enough that you can drag and drop the header and 
 
 Building unit tests requires [Boost.Test](http://www.boost.org/doc/libs/release/libs/test/). To build the tests you will also need to have either unixODBC or iODBC installed and discoverable by CMake. This is easy on OS X where you can use [Homebrew](http://brew.sh/) to install unixODBC with `brew install unixodbc`, or use the system provided iODBC if you have OS X 10.9 or earlier. Also note that you can install Boost via Homebrew as well, which is super convenient!
 
-The unit tests attempt to connect to a [SQLite](https://www.sqlite.org/) database, so you will have to have that and a SQLite ODBC driver installed. At the time of this writing, there happens to be a nice [SQLite ODBC driver](http://www.ch-werner.de/sqliteodbc/) available from Christian Werner's website. The tests expect to find a data source named `sqlite`. For example, your `odbcinst.ini` file on OS X will have a section like the following.
+The unit tests attempt to connect to a [SQLite](https://www.sqlite.org/) database, so you will have to have that and a SQLite ODBC driver installed. At the time of this writing, there happens to be a nice [SQLite ODBC driver](http://www.ch-werner.de/sqliteodbc/) available from Christian Werner's website, also available via Homebrew as `sqliteobdc`! The tests expect to find a data source named `sqlite` on *nix systems and `SQLite3 ODBC Driver` on Windows systems. For example, your `odbcinst.ini` file on OS X will have a section like the following.
 
 ```
 [sqlite]
-Description             = SQLite ODBC
+Description             = SQLite3 ODBC Driver
 Driver                  = /usr/lib/libsqlite3odbc-0.93.dylib
 Setup                   = /usr/lib/libsqlite3odbc-0.93.dylib
 Threading               = 2

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -23,7 +23,7 @@ namespace
 #ifdef _WIN32
     const nanodbc::string_type driver_name(NANODBC_TEXT("SQLite3 ODBC Driver"));
 #else
-    const nanodbc::string_type driver_name(NANODBC_TEXT("SQLite3"));
+    const nanodbc::string_type driver_name(NANODBC_TEXT("sqlite"));
 #endif
     const nanodbc::string_type connection_string
         = NANODBC_TEXT("Driver=") + driver_name


### PR DESCRIPTION
The .dmg for sqliteodbc on Christian Werner's website no longer works on
OS X El Capitan and later. However, it is now available on Homebrew.