### PR TITLE
Fix result::position to make it consistent with SQL_ATTR_ROW_NUMBER.

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1938,7 +1938,7 @@ public:
         //
         // NOTE: We try to address incorrect implementation in some drivers (e.g. SQLite ODBC)
         // which instead of 0 return SQL_ROW_NUMBER_UNKNOWN(-2) .
-        if (pos == 0 || pos == SQL_ROW_NUMBER_UNKNOWN)
+        if (pos == 0 || pos == static_cast<SQLULEN>(SQL_ROW_NUMBER_UNKNOWN))
             return 0;
 
         NANODBC_ASSERT(pos <= static_cast<SQLULEN>(std::numeric_limits<unsigned long>::max()));

--- a/test/basic_test.h
+++ b/test/basic_test.h
@@ -320,7 +320,9 @@ struct basic_test
             BOOST_CHECK(results_copy.get<nanodbc::string_type>(1) == NANODBC_TEXT("two"));
             BOOST_CHECK(results_copy.get<nanodbc::string_type>(NANODBC_TEXT("b")) == NANODBC_TEXT("two"));
 
-            BOOST_CHECK(results.position());
+            // FIXME: not supported by the default SQL_CURSOR_FORWARD_ONLY
+            // and will require SQL_ATTR_CURSOR_TYPE set to SQL_CURSOR_STATIC at least.
+            //BOOST_CHECK(results.position());
 
             nanodbc::result().swap(results_copy);
 


### PR DESCRIPTION
If the number of the current row cannot be determined or there is no current row, the driver returns 0.
Otherwise, valid row number is returned, starting at 1.

Handle some incorrect driver implementations (e.g. SQLite ODBC) which instead of 0 return `SQL_ROW_NUMBER_UNKNOWN` (see #71).

Disable test check of `result::position` as not supported by the default `SQL_CURSOR_FORWARD_ONLY`, until cursor type configuration is supported (see #78).

This PR has been tested assuming `odbc_test` is present, so depends on #81.
Also, in order to confirm the fix, I locally enabled `SQL_CURSOR_STATIC` for statement under test.

-----
**NOTE**:
Previous implementation of `result::position` included subtraction of `-1` which had somewhat changed original semantic of `SQL_ATTR_ROW_NUMBER`:
```
return static_cast<unsigned long>(pos) - 1 + rowset_position_;
```
if `pos==0`, it would return overflown "wrapped-around" unsigned value.

This PR removed the `-1` term from the expression.

To summary:
1. I think, `result::position` should conform to semantic of `SQL_ATTR_ROW_NUMBER` exactly and respect the **1-based** numbering of rows. This variant is implemented in this PR.
2. If we still wanted to the custom 0-based numbering, we would have to define a kind `std::string`-like `npos` value to return if the current row can not be determined.
