### PR TITLE
Add database_name and catalog_name methods to connection class

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -892,6 +892,47 @@ public:
         return string_type(&name[0], &name[strarrlen(name)]);
     }
 
+    string_type database_name() const
+    {
+        // FIXME: Allocate buffer of dynamic size as drivers do not agree on universal size
+        // MySQL driver limits MAX_NAME_LEN=255
+        // PostgreSQL driver MAX_INFO_STIRNG=128
+        // MFC CDatabase allocates buffer dynamically.
+        NANODBC_SQLCHAR name[255] = { 0 };
+        SQLSMALLINT length(0);
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            NANODBC_UNICODE(SQLGetInfo)
+            , rc
+            , conn_
+            , SQL_DATABASE_NAME
+            , name
+            , sizeof(name) / sizeof(NANODBC_SQLCHAR)
+            , &length);
+        if(!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+        return string_type(&name[0], &name[strarrlen(name)]);
+    }
+
+    string_type catalog_name() const
+    {
+        NANODBC_SQLCHAR name[SQL_MAX_OPTION_STRING_LENGTH] = { 0 };
+        SQLINTEGER length(0);
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            NANODBC_UNICODE(SQLGetConnectAttr)
+            , rc
+            , conn_
+            , SQL_ATTR_CURRENT_CATALOG
+            , name
+            , sizeof(name) / sizeof(NANODBC_SQLCHAR)
+            , &length);
+        if(!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+        return string_type(&name[0], &name[strarrlen(name)]);
+    }
+
+
     std::size_t ref_transaction()
     {
         return --transactions_;
@@ -2790,6 +2831,16 @@ void* connection::native_env_handle() const
 string_type connection::driver_name() const
 {
     return impl_->driver_name();
+}
+
+string_type connection::database_name() const
+{
+    return impl_->database_name();
+}
+
+string_type connection::catalog_name() const
+{
+    return impl_->catalog_name();
 }
 
 std::size_t connection::ref_transaction()

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -848,6 +848,14 @@ public:
     //! \throws database_error
     string_type driver_name() const;
 
+    //! \brief Returns the name of the currently connected database.
+    //! Returns the current SQL_DATABASE_NAME information value associated with the connection.
+    string_type database_name() const;
+
+    //! \brief Returns the name of the current catalog.
+    //! Returns the current setting of the connection attribute SQL_ATTR_CURRENT_CATALOG.
+    string_type catalog_name() const;
+
 private:
     std::size_t ref_transaction();
     std::size_t unref_transaction();


### PR DESCRIPTION
This PR adds two functions for user convenience to query, for the current connection, values of 
* `SQL_DATABASE_NAME` information (ODBC 1.0)
* `SQL_ATTR_CURRENT_CATALOG` attribute setting (ODBC 3.0)

In general case, both return the same value, but I'm not sure if all drivers behave in the same way.
Since the two properties are defined in ODBC API, think it's good give access to both.

If the PR is merged, I'm going add a basic test for those at some point.