### PR TITLE
Add dbms_name and dbms_version methods to connection class

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -888,6 +888,42 @@ public:
         return env_;
     }
 
+    string_type dbms_name() const
+    {
+        NANODBC_SQLCHAR name[255] = { 0 };
+        SQLSMALLINT length(0);
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            NANODBC_UNICODE(SQLGetInfo)
+            , rc
+            , conn_
+            , SQL_DBMS_NAME
+            , name
+            , sizeof(name) / sizeof(NANODBC_SQLCHAR)
+            , &length);
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+        return string_type(&name[0], &name[strarrlen(name)]);
+    }
+
+    string_type dbms_version() const
+    {
+        NANODBC_SQLCHAR version[255] = { 0 };
+        SQLSMALLINT length(0);
+        RETCODE rc;
+        NANODBC_CALL_RC(
+            NANODBC_UNICODE(SQLGetInfo)
+            , rc
+            , conn_
+            , SQL_DBMS_VER
+            , version
+            , sizeof(version) / sizeof(NANODBC_SQLCHAR)
+            , &length);
+        if (!success(rc))
+            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+        return string_type(&version[0], &version[strarrlen(version)]);
+    }
+
     string_type driver_name() const
     {
         NANODBC_SQLCHAR name[1024];
@@ -2857,6 +2893,16 @@ void* connection::native_dbc_handle() const
 void* connection::native_env_handle() const
 {
     return impl_->native_env_handle();
+}
+
+string_type connection::dbms_name() const
+{
+    return impl_->dbms_name();
+}
+
+string_type connection::dbms_version() const
+{
+    return impl_->dbms_version();
 }
 
 string_type connection::driver_name() const

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -847,6 +847,16 @@ public:
     //! \brief Returns the native ODBC environment handle.
     void* native_env_handle() const;
 
+    //! \brief Returns name of the DBMS product.
+    //! Returns the ODBC information type SQL_DBMS_NAME of the DBMS product
+    //! accesssed by the driver via the current connection.
+    string_type dbms_name() const;
+
+    //! \brief Returns version of the DBMS product.
+    //! Returns the ODBC information type SQL_DBMS_VER of the DBMS product
+    //! accesssed by the driver via the current connection.
+    string_type dbms_version() const;
+
     //! \brief Returns the name of the ODBC driver.
     //! \throws database_error
     string_type driver_name() const;

--- a/test/basic_test.h
+++ b/test/basic_test.h
@@ -99,6 +99,16 @@ struct basic_test
 
     // Test Cases
 
+    void dbms_info_test()
+    {
+        // A generic test to exercise the DBMS info API is callable.
+        // DBMS-specific test (MySQL, SQLite, etc.) may perform extended checks.
+
+        nanodbc::connection connection = connect();
+        BOOST_CHECK(!connection.dbms_name().empty());
+        BOOST_CHECK(!connection.dbms_version().empty());
+    }
+
     void catalog_columns_test()
     {
         nanodbc::connection connection = connect();
@@ -262,6 +272,7 @@ struct basic_test
             BOOST_CHECK(!keys.next());
         }
     }
+    
     void catalog_tables_test()
     {
         nanodbc::connection connection = connect();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -23,6 +23,10 @@ namespace
 
 BOOST_FIXTURE_TEST_SUITE(odbc, odbc_fixture)
 
+BOOST_AUTO_TEST_CASE(dbms_info_test)
+{
+    test.dbms_info_test();
+}
 
 BOOST_AUTO_TEST_CASE(decimal_conversion_test)
 {

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -23,6 +23,11 @@ namespace
 
 BOOST_FIXTURE_TEST_SUITE(odbc, odbc_fixture)
 
+BOOST_AUTO_TEST_CASE(dbms_info_test)
+{
+    test.dbms_info_test();
+}
+
 BOOST_AUTO_TEST_CASE(catalog_columns_test)
 {
     test.catalog_columns_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -62,6 +62,15 @@ namespace
 
 BOOST_FIXTURE_TEST_SUITE(sqlite, sqlite_fixture)
 
+BOOST_AUTO_TEST_CASE(dbms_info_test)
+{
+    test.dbms_info_test();
+
+    // Additional SQLite-specific checks
+    nanodbc::connection connection = test.connect();
+    BOOST_CHECK(connection.dbms_name() == NANODBC_TEXT("SQLite"));
+}
+
 BOOST_AUTO_TEST_CASE(decimal_conversion_test)
 {
     // SQLite ODBC driver requires dedicated test.


### PR DESCRIPTION
The new methods allow to query the DBMS product information, name and version, available via the corresponding ODBC information type descriptors ([SQL_DBMS_NAME and SQL_DBMS_VER](https://msdn.microsoft.com/en-us/library/ms711681.aspx)).

Basic tests included. Tested against SQLite 3, PostgreSQL and SQL Server.