### PR TITLE
Propose more portable test for a table presence.

### DIFF
--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -117,7 +117,17 @@ struct base_test_fixture
 
     virtual void drop_table(nanodbc::connection& connection, const nanodbc::string_type& name) const
     {
-        execute(connection, NANODBC_TEXT("DROP TABLE IF EXISTS ") + name + NANODBC_TEXT(";"));
+        try
+        {
+            // create empty result set as a poor man's portable "IF EXISTS" test
+            nanodbc::result results = execute(connection,
+                NANODBC_TEXT("SELECT * FROM ") + name + NANODBC_TEXT(" WHERE 0=1;"));
+            execute(connection, NANODBC_TEXT("DROP TABLE ") + name + NANODBC_TEXT(";"));
+        }
+        catch (...)
+        {
+            ; // assume table does not exist
+        }
     }
 
     // Test Cases


### PR DESCRIPTION
Remove non-standard `IF EXISTS` syntax from `DROP TABLE`.
Use query based check if a table exists.

Since the `odbc_test.cpp` is a generic test, it may be a good idea to keep it clear from non-standard SQL statements.