### PR TITLE
Fix check of total of characters required to display SQL_DATE.

### DIFF
--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -212,7 +212,7 @@ struct base_test_fixture
             REQUIRE(columns.next());
             REQUIRE(columns.column_name() == NANODBC_TEXT("c4"));
             REQUIRE(columns.sql_data_type() == SQL_DATE);
-            REQUIRE(columns.column_size() == 23); // total number of characters required to display the value when it is converted to characters
+            REQUIRE(columns.column_size() == 10); // total number of characters required to display the value when it is converted to characters
 
             REQUIRE(columns.next());
             REQUIRE(columns.column_name() == NANODBC_TEXT("c5"));


### PR DESCRIPTION
The [ODBC reference](https://msdn.microsoft.com/en-us/library/ms711786.aspx) in MSDN also confirms, the total number of characters required to display the value of type of `SQL_DATE` is **10**, not 23.

This has been confirmed with SQL Server and PostgreSQL