### PR TITLE
Improve odbc_test.cpp to cope with DBMS variations.

### DIFF
--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -258,7 +258,7 @@ struct base_test_fixture
             REQUIRE(columns.column_name() == NANODBC_TEXT("c5"));
             REQUIRE((columns.sql_data_type() == SQL_VARCHAR || columns.sql_data_type() == SQL_WVARCHAR));
             REQUIRE(columns.column_size() == 60);
-            REQUIRE(columns.column_default().find(NANODBC_TEXT("\'sample value\'")) != nanodbc::string_type::npos);
+            REQUIRE(contains_string(columns.column_default(), NANODBC_TEXT("\'sample value\'")));
 
             REQUIRE(columns.next());
             REQUIRE(columns.column_name() == NANODBC_TEXT("c6"));


### PR DESCRIPTION
The test has been updated and corrected to successfully pass against SQL Server 2012 and PostgreSQL 9.x. Hurray!

Existing `TODO` comments have been refined to reflect the current status of the test.