### PR TITLE
Fix retrival of variable-length data in parts.

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2525,8 +2525,11 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         ss << buff;
                     else if(ValueLenOrInd == SQL_NULL_DATA)
                         *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
-                } while(rc > 0);
-                convert(ss.str(), result);
+                    // Sequence of successful calls is:
+                    // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
+                } while(rc == SQL_SUCCESS_WITH_INFO);
+                if (rc == SQL_SUCCESS || rc == SQL_NO_DATA)
+                    convert(ss.str(), result);
             }
             else
             {
@@ -2564,8 +2567,11 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         ss << buffer;
                     else if(ValueLenOrInd == SQL_NULL_DATA)
                         *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
-                } while(rc > 0);
-                convert(ss.str(), result);
+                    // Sequence of successful calls is:
+                    // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
+                } while(rc == SQL_SUCCESS_WITH_INFO);
+                if (rc == SQL_SUCCESS || rc == SQL_NO_DATA)
+                    convert(ss.str(), result);
             }
             else
             {


### PR DESCRIPTION
The termination condition of the loop in which `SQLGetData` is called to retrieve varlen data in chunks was incomplete and incorrect. It only tested `SQLGetData` return code is **greater than 0**, what led to infinite loop in case the call returned `SQL_NO_DATA(100)`.

The issue has been reproduced number of times while querying variable-length data from SQL Server,
and the MSDN confirms `SQL_NO_DATA` is a valid return code for `SQLGetData`. So, it should be handled properly.

Test for this fix is not included, but it needs to be added soon.