### PR TITLE
Work around VS2015 bug in std::codecvt for char16_t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ language: cpp
 compiler:
   - gcc
 env:
-  - DB=mysql USE_UNICODE=OFF USE_BOOST_CONVERT=OFF
-  - DB=mysql USE_UNICODE=OFF USE_BOOST_CONVERT=ON
-  - DB=mysql USE_UNICODE=ON USE_BOOST_CONVERT=OFF
-  - DB=mysql USE_UNICODE=ON USE_BOOST_CONVERT=ON
-  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF
-  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON
-  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=OFF
-  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=ON
+  - DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+  - DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+  - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+  - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=ON
+  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=ON
 before_install:
   - if [[ "$DB" == "sqlite" ]]; then sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini; fi
   - if [[ "$DB" == "mysql" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
@@ -39,9 +39,7 @@ before_script:
 script:
   - mkdir build
   - cd build
-  - cmake -D NANODBC_USE_UNICODE=${USE_UNICODE} -D NANODBC_USE_BOOST_CONVERT=${USE_BOOST_CONVERT} -D NANODBC_ENABLE_LIBCXX=NO ..
+  - cmake -D NANODBC_USE_UNICODE=${USE_UNICODE} -D NANODBC_USE_BOOST_CONVERT=${USE_BOOST_CONVERT} -D NANODBC_HANDLE_NODATA_BUG=${USE_NODATA_BUG} -D NANODBC_ENABLE_LIBCXX=NO ..
   - make
-  # FIXME: Unicode enabled SQLite tests not working on Linux builds.
-  - if [[ "$DB" == "sqlite" && $USE_UNICODE == "OFF" ]]; then make VERBOSE=1 sqlite_check; fi
-  # FIXME: Unicode enabled MySQL tests not working on Linux builds.
-  - if [[ "$DB" == "mysql" && $USE_UNICODE == "OFF" ]]; then make VERBOSE=1 mysql_check; fi
+  - if [[ "$DB" == "sqlite" ]]; then make VERBOSE=1 sqlite_check; fi
+  - if [[ "$DB" == "mysql" ]]; then make VERBOSE=1 mysql_check; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,29 @@
-FROM ubuntu:latest
+# FROM ubuntu:latest
+# RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+#     DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common
 
+# travis-ci unit tests run using ubuntu:precise, but development is often
+# far less painful using ubuntu:latest instead. In future we can drop precise.
+FROM ubuntu:precise
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common
+    DEBIAN_FRONTEND=noninteractive apt-get -y install python-software-properties
+
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        $(apt-cache -q search "libboost-locale1\..*-dev" | awk '{print $1}') \
         cmake \
         g++-5 \
         git \
-        libboost-locale1.55-dev \
-        libboost-test1.55-dev \
         libmyodbc \
         libsqliteodbc \
+        make \
         mysql-client \
         mysql-server \
+        sqlite3 \
         unixodbc \
-        unixodbc-dev
+        unixodbc-dev \
+        vim
 
 RUN odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini
 RUN odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,6 @@ sudo apt-get -y -q install \
     g++-5 \
     git \
     libboost-locale1.55-dev \
-    libboost-test1.55-dev \
     libmyodbc \
     libsqliteodbc \
     mysql-client \

--- a/examples/example_unicode_utils.h
+++ b/examples/example_unicode_utils.h
@@ -1,0 +1,37 @@
+#ifndef NANODBC_UNICODE_UTILS_H
+#define NANODBC_UNICODE_UTILS_H
+
+#include "nanodbc.h"
+
+#include <codecvt>
+#include <locale>
+#include <string>
+
+#ifdef NANODBC_USE_UNICODE
+    #undef NANODBC_TEXT
+    #define NANODBC_TEXT(s) u ## s
+
+    inline nanodbc::string_type convert(std::string const& in)
+    {
+        std::u16string out;
+        out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(in);
+        return out;
+    }
+
+    inline std::string convert(nanodbc::string_type const& in)
+    {
+        std::string out;
+        out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(in);
+        return out;
+    }
+#else
+    #undef NANODBC_TEXT
+    #define NANODBC_TEXT(s) s
+
+    inline nanodbc::string_type convert(std::string const& in)
+    {
+        return in;
+    }
+#endif
+
+#endif // NANODBC_UNICODE_UTILS_H

--- a/examples/example_unicode_utils.h
+++ b/examples/example_unicode_utils.h
@@ -14,14 +14,26 @@
     inline nanodbc::string_type convert(std::string const& in)
     {
         std::u16string out;
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
+        auto s = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(in);
+        auto p = reinterpret_cast<char16_t const*>(s.data());
+        out.assign(p, p + s.size());
+#else
         out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(in);
+#endif
         return out;
     }
 
     inline std::string convert(nanodbc::string_type const& in)
     {
         std::string out;
+#if defined(_MSC_VER) && (_MSC_VER == 1900)
+        std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t> convert;
+        auto p = reinterpret_cast<const int16_t *>(in.data());
+        out = convert.to_bytes(p, p + in.size());
+#else
         out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(in);
+#endif
         return out;
     }
 #else

--- a/examples/northwind.cpp
+++ b/examples/northwind.cpp
@@ -1,44 +1,34 @@
-#include <stdexcept>
-#include <iostream>
-#include <string>
 #include "nanodbc.h"
+#include "example_unicode_utils.h"
 
-#ifndef NANODBC_TEXT
-#ifdef NANODBC_USE_UNICODE
-#define NANODBC_TEXT(s) L ## s
-#else
-#define NANODBC_TEXT(s) s
-#endif
-#endif
+#include <iostream>
+#include <stdexcept>
+#include <string>
 
-#ifdef NANODBC_USE_UNICODE
-auto& console = std::wcout;
-#else
-auto& console = std::cout;
-#endif
+using namespace std;
+using namespace nanodbc;
 
 int main()
 {
     try
     {
-        nanodbc::connection conn(NANODBC_TEXT("NorthWind"));
-        nanodbc::result row = execute(conn, NANODBC_TEXT(
+        connection conn(NANODBC_TEXT("NorthWind"));
+        result row = execute(conn, NANODBC_TEXT(
             "SELECT CustomerID, ContactName, Phone"
             "   FROM CUSTOMERS"
             "   ORDER BY 2, 1, 3"));
 
         for (int i = 1; row.next(); ++i)
         {
-            console
-                << i << NANODBC_TEXT(" :")
-                << row.get<nanodbc::string_type>(0) << NANODBC_TEXT(" ")
-                << row.get<nanodbc::string_type>(1) << NANODBC_TEXT(" ")
-                << row.get<nanodbc::string_type>(2) << NANODBC_TEXT(" ")
-                << std::endl;
+            cout << i << " :"
+                << convert(row.get<string_type>(0)) << " "
+                << convert(row.get<string_type>(1)) << " "
+                << convert(row.get<string_type>(2)) << " "
+                << endl;
         }
     }
-    catch (std::runtime_error const& e)
+    catch (runtime_error const& e)
     {
-        std::cerr << e.what() << std::endl;
+        cerr << e.what() << endl;
     }
 }

--- a/examples/rowset_iteration.cpp
+++ b/examples/rowset_iteration.cpp
@@ -1,56 +1,31 @@
+#include "nanodbc.h"
+#include "example_unicode_utils.h"
+
 #include <algorithm>
 #include <array>
 #include <codecvt>
 #include <cstring>
 #include <iostream>
-#include <locale>
 #include <stdexcept>
 #include <string>
-#include "nanodbc.h"
+
+using namespace std;
 using namespace nanodbc;
 
-#ifndef NANODBC_TEXT
-#ifdef NANODBC_USE_UNICODE
-#define NANODBC_TEXT(s) L ## s
-#else
-#define NANODBC_TEXT(s) s
-#endif
-#endif
-
-#ifdef NANODBC_USE_UNICODE
-inline nanodbc::string_type convert(std::string const & in)
+void usage(ostream& out, string const& binary_name)
 {
-    std::wstring out;
-    out = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(in);
-    return out;
-}
-#else
-inline nanodbc::string_type convert(std::string const & in)
-{
-    return in;
-}
-#endif
-
-#ifdef NANODBC_USE_UNICODE
-auto& console = std::wcout;
-#else
-auto& console = std::cout;
-#endif
-
-void usage(std::ostream& out, std::string const& binary_name)
-{
-    out << "usage: " << binary_name << " connection_string" << std::endl;
+    out << "usage: " << binary_name << " connection_string" << endl;
 }
 
 int main(int argc, char* argv[])
 {
     if(argc != 2)
     {
-        char* app_name = std::strrchr(argv[0], '/');
+        char* app_name = strrchr(argv[0], '/');
         app_name = app_name ? app_name + 1 : argv[0];
-        if(0 == std::strncmp(app_name, "lt-", 3))
+        if(0 == strncmp(app_name, "lt-", 3))
             app_name += 3; // remove libtool prefix
-        usage(std::cerr, app_name);
+        usage(cerr, app_name);
         return EXIT_FAILURE;
     }
 
@@ -67,7 +42,7 @@ int main(int argc, char* argv[])
             {
                 // XXX: SQL Server <=2014 does not support "if exists"
                 execute(conn, NANODBC_TEXT("drop table rowset_iteration;"));
-            } catch (std::runtime_error const&) {}
+            } catch (runtime_error const&) {}
 
             execute(conn, NANODBC_TEXT("create table rowset_iteration (i int);"));
         }
@@ -76,27 +51,29 @@ int main(int argc, char* argv[])
         {
             statement stmt(conn);
             prepare(stmt, NANODBC_TEXT("insert into rowset_iteration (i) values (?);"));
-            std::array<int, 5> const numbers {{ 100, 80, 60, 40, 20 }};
+            array<int, 5> const numbers {{ 100, 80, 60, 40, 20 }};
             stmt.bind(0, numbers.data(), numbers.size());
             transact(stmt, static_cast<long>(numbers.size()));
         }
 
         // Select and fetch
         long batch_size = 1; // tweak to play with number of ODBC fetch calls
-        nanodbc::result result = execute(conn, NANODBC_TEXT(
-            "SELECT i FROM rowset_iteration ORDER BY i DESC;"), batch_size);
+        result result = execute(
+            conn
+            , NANODBC_TEXT("SELECT i FROM rowset_iteration ORDER BY i DESC;")
+            , batch_size);
         for (int i = 1; result.next(); ++i)
         {
-            console << i
-                << NANODBC_TEXT("(") << result.rows()
-                << NANODBC_TEXT("/") << result.rowset_size()
-                << NANODBC_TEXT("):")
+            cout << i
+                << "(" << result.rows()
+                << "/" << result.rowset_size()
+                << ":"
                 << result.get<int>(0)
-                << std::endl;
+                << endl;
         }
     }
-    catch (std::runtime_error const& e)
+    catch (runtime_error const& e)
     {
-        std::cerr << e.what() << std::endl;
+        cerr << e.what() << endl;
     }
 }

--- a/examples/usage.cpp
+++ b/examples/usage.cpp
@@ -1,9 +1,13 @@
 #include "nanodbc.h"
-#include <iostream>
-using namespace std;
-#ifndef NANODBC_USE_UNICODE
+
 #include <algorithm>
 #include <cstring>
+#include <iostream>
+
+using namespace std;
+using namespace nanodbc;
+
+#ifndef NANODBC_USE_UNICODE
 
 void show(nanodbc::result& results);
 
@@ -88,7 +92,7 @@ void run_test(const char* connection_string)
         execute(connection, "create table public.batch_test (x varchar(10), y int, z float);");
         prepare(statement, "insert into public.batch_test (x, y, z) values (?, ?, ?);");
 
-        const std::size_t elements = 4;
+        const size_t elements = 4;
 
         char xdata[elements][10] = { "this", "is", "a", "test" };
         statement.bind_strings(0, xdata);
@@ -103,7 +107,7 @@ void run_test(const char* connection_string)
 
         results = execute(connection, "select * from public.batch_test;", 3);
         show(results);
-    
+
         execute(connection, "drop table if exists public.batch_test;");
     }
 
@@ -132,7 +136,7 @@ void run_test(const char* connection_string)
 
         const int elements = 5;
         const int a_null = 0;
-        const char* b_null = ""; 
+        const char* b_null = "";
         int a_data[elements] = {0, 88, 0, 0, 0};
         char b_data[elements][10] = {"", "non-null", "", "", ""};
 
@@ -192,20 +196,20 @@ void show(nanodbc::result& results)
     }
 }
 
-void usage(std::ostream& out, std::string const& binary_name)
+void usage(ostream& out, string const& binary_name)
 {
-    out << "usage: " << binary_name << " connection_string" << std::endl;
+    out << "usage: " << binary_name << " connection_string" << endl;
 }
 
 int main(int argc, char* argv[])
 {
     if(argc != 2)
     {
-        char* app_name = std::strrchr(argv[0], '/');
+        char* app_name = strrchr(argv[0], '/');
         app_name = app_name ? app_name + 1 : argv[0];
-        if(0 == std::strncmp(app_name, "lt-", 3))
+        if(0 == strncmp(app_name, "lt-", 3))
             app_name += 3; // remove libtool prefix
-        usage(std::cerr, app_name);
+        usage(cerr, app_name);
         return 1;
     }
 
@@ -221,10 +225,11 @@ int main(int argc, char* argv[])
 }
 
 #else
+
 int main(int /*argc*/, char* argv[])
 {
-    cout << argv[0] << " does not support use of Unicode." << std::endl;
-    cout << "Compile it without NANODBC_USE_UNICODE preprocessor define." << std::endl;
-
+    cout << argv[0] << " does not support use of Unicode." << endl;
+    cout << "Compile it without NANODBC_USE_UNICODE preprocessor define." << endl;
 }
-#endif
+
+#endif // NANODBC_USE_UNICODE

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -195,7 +195,12 @@ namespace
             using boost::locale::conv::utf_to_utf;
             out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
         #else
+            #if defined(_MSC_VER) && (_MSC_VER == 1900)
+            auto p = reinterpret_cast<int16_t const*>(in.data());
+            out = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().to_bytes(p, p + in.size());
+            #else
             out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(in);
+            #endif
         #endif
     }
 
@@ -206,7 +211,13 @@ namespace
                 using boost::locale::conv::utf_to_utf;
                 out = utf_to_utf<char16_t>(in.c_str(), in.c_str() + in.size());
             #else
+            #if defined(_MSC_VER) && (_MSC_VER == 1900)
+                auto s = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(in);
+                auto p = reinterpret_cast<char16_t const*>(s.data());
+                out.assign(p, p + s.size());
+            #else
                 out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(in);
+            #endif
             #endif
         }
 

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -13,7 +13,6 @@
 #include <ctime>
 #include <iomanip>
 #include <map>
-#include <sstream>
 
 #ifndef __clang__
     #include <cstdint>
@@ -21,8 +20,8 @@
 
 // User may redefine NANODBC_ASSERT macro in nanodbc.h
 #ifndef NANODBC_ASSERT
-#include <cassert>
-#define NANODBC_ASSERT(expr) assert(expr)
+    #include <cassert>
+    #define NANODBC_ASSERT(expr) assert(expr)
 #endif
 
 #ifdef NANODBC_USE_BOOST_CONVERT
@@ -73,46 +72,22 @@
 //  "Y88888P"  888  888 888  "Y8888P "Y88P"   "Y88888  "Y8888
 // MARK: Unicode -
 
-#if defined(_MSC_VER)
-    #ifdef NANODBC_USE_UNICODE
-        #define NANODBC_TEXT(s) L ## s
-        #define NANODBC_SNPRINTF std::swprintf
-        #define NANODBC_STRFTIME std::wcsftime
-        #define NANODBC_STRLEN std::wcslen
-        #define NANADBC_STRNCMP std::wcsncmp
-        #define NANODBC_UNICODE(f) f ## W
-        #define NANODBC_SQLCHAR SQLWCHAR
-    #else
-        #define NANODBC_TEXT(s) s
-        #define NANODBC_SNPRINTF(buffer, count, format, ...) _snprintf_s(buffer, count, _TRUNCATE, format, __VA_ARGS__)
-        #define NANODBC_STRFTIME std::strftime
-        #define NANODBC_STRLEN std::strlen
-        #define NANADBC_STRNCMP std::strncmp
-        #define NANODBC_UNICODE(f) f
-        #define NANODBC_SQLCHAR SQLCHAR
+#ifdef NANODBC_USE_UNICODE
+    #define NANODBC_TEXT(s) u ## s
+    #define NANODBC_FUNC(f) f ## W
+    #define NANODBC_SQLCHAR SQLWCHAR
+#else
+    #define NANODBC_TEXT(s) s
+    #define NANODBC_FUNC(f) f
+    #define NANODBC_SQLCHAR SQLCHAR
+#endif
 
+#if defined(_MSC_VER)
+    #ifndef NANODBC_USE_UNICODE
         // Disable unicode in sqlucode.h on Windows when NANODBC_USE_UNICODE
         // is not defined. This is required because unicode is enabled by
         // default on many Windows systems.
         #define SQL_NOUNICODEMAP
-    #endif
-#else
-    #ifdef NANODBC_USE_UNICODE
-        #define NANODBC_TEXT(s) L ## s
-        #define NANODBC_SNPRINTF std::swprintf
-        #define NANODBC_STRFTIME std::wcsftime
-        #define NANODBC_STRLEN std::wcslen
-        #define NANADBC_STRNCMP std::wcsncmp
-        #define NANODBC_UNICODE(f) f ## W
-        #define NANODBC_SQLCHAR SQLWCHAR
-    #else
-        #define NANODBC_TEXT(s) s
-        #define NANODBC_SNPRINTF std::snprintf
-        #define NANODBC_STRFTIME std::strftime
-        #define NANODBC_STRLEN std::strlen
-        #define NANADBC_STRNCMP std::strncmp
-        #define NANODBC_UNICODE(f) f
-        #define NANODBC_SQLCHAR SQLCHAR
     #endif
 #endif
 
@@ -214,28 +189,28 @@ namespace
         return i;
     }
 
-    inline void convert(const std::wstring& in, std::string& out)
+    inline void convert(const std::u16string& in, std::string& out)
     {
         #ifdef NANODBC_USE_BOOST_CONVERT
             using boost::locale::conv::utf_to_utf;
             out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
         #else
-            out = std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(in);
+            out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().to_bytes(in);
         #endif
     }
 
     #ifdef NANODBC_USE_UNICODE
-        inline void convert(const std::string& in, std::wstring& out)
+        inline void convert(const std::string& in, std::u16string& out)
         {
             #ifdef NANODBC_USE_BOOST_CONVERT
                 using boost::locale::conv::utf_to_utf;
-                out = utf_to_utf<wchar_t>(in.c_str(), in.c_str() + in.size());
+                out = utf_to_utf<char16_t>(in.c_str(), in.c_str() + in.size());
             #else
-                out = std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(in);
+                out = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(in);
             #endif
         }
 
-        inline void convert(const std::wstring& in, std::wstring & out)
+        inline void convert(const std::u16string& in, std::u16string& out)
         {
             out = in;
         }
@@ -268,7 +243,7 @@ namespace
         do
         {
             NANODBC_CALL_RC(
-                NANODBC_UNICODE(SQLGetDiagRec)
+                NANODBC_FUNC(SQLGetDiagRec)
                 , rc
                 , handle_type
                 , handle
@@ -286,7 +261,7 @@ namespace
                 break;
 
             NANODBC_CALL_RC(
-                NANODBC_UNICODE(SQLGetDiagRec)
+                NANODBC_FUNC(SQLGetDiagRec)
                 , rc
                 , handle_type
                 , handle
@@ -786,7 +761,7 @@ public:
         #endif
 
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLConnect)
+            NANODBC_FUNC(SQLConnect)
             , rc
             , conn_
             , (NANODBC_SQLCHAR*)dsn.c_str(), SQL_NTS
@@ -838,7 +813,7 @@ public:
         NANODBC_SQLCHAR dsn[1024];
         SQLSMALLINT dsn_size = 0;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLDriverConnect)
+            NANODBC_FUNC(SQLDriverConnect)
             , rc
             , conn_
             , 0
@@ -894,7 +869,7 @@ public:
         SQLSMALLINT length(0);
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLGetInfo)
+            NANODBC_FUNC(SQLGetInfo)
             , rc
             , conn_
             , SQL_DBMS_NAME
@@ -912,7 +887,7 @@ public:
         SQLSMALLINT length(0);
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLGetInfo)
+            NANODBC_FUNC(SQLGetInfo)
             , rc
             , conn_
             , SQL_DBMS_VER
@@ -930,7 +905,7 @@ public:
         SQLSMALLINT length;
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLGetInfo)
+            NANODBC_FUNC(SQLGetInfo)
             , rc
             , conn_
             , SQL_DRIVER_NAME
@@ -952,7 +927,7 @@ public:
         SQLSMALLINT length(0);
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLGetInfo)
+            NANODBC_FUNC(SQLGetInfo)
             , rc
             , conn_
             , SQL_DATABASE_NAME
@@ -970,7 +945,7 @@ public:
         SQLINTEGER length(0);
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLGetConnectAttr)
+            NANODBC_FUNC(SQLGetConnectAttr)
             , rc
             , conn_
             , SQL_ATTR_CURRENT_CATALOG
@@ -1283,7 +1258,7 @@ public:
 
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLPrepare)
+            NANODBC_FUNC(SQLPrepare)
             , rc
             , stmt_
             , (NANODBC_SQLCHAR*)query.c_str()
@@ -1428,7 +1403,7 @@ public:
         this->timeout(timeout);
 
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLExecDirect)
+            NANODBC_FUNC(SQLExecDirect)
             , rc
             , stmt_
             , (NANODBC_SQLCHAR*)query.c_str()
@@ -1507,7 +1482,7 @@ public:
 
         RETCODE rc;
         NANODBC_CALL_RC(
-            NANODBC_UNICODE(SQLProcedureColumns)
+            NANODBC_FUNC(SQLProcedureColumns)
             , rc
             , stmt_
             , (NANODBC_SQLCHAR*)(catalog.empty() ? NULL : catalog.c_str())
@@ -1835,12 +1810,23 @@ void statement::statement_impl::bind_strings(
 
     if(null_sentry)
     {
-        const string_type rhs(null_sentry);
         for(std::size_t i = 0; i < elements; ++i)
         {
-            const string_type lhs(values + i * length, values + (i + 1) * length);
-            if(NANADBC_STRNCMP(lhs.c_str(), rhs.c_str(), length))
-                bind_len_or_null_[param][i] = parameter_size;
+            const string_type s_lhs(values + i * length, values + (i + 1) * length);
+            const string_type s_rhs(null_sentry);
+            #if NANODBC_USE_UNICODE
+                std::string narrow_lhs;
+                narrow_lhs.reserve(s_lhs.size());
+                convert(s_lhs, narrow_lhs);
+                std::string narrow_rhs;
+                narrow_rhs.reserve(s_rhs.size());
+                convert(s_rhs, narrow_lhs);
+                if(std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length))
+                    bind_len_or_null_[param][i] = parameter_size;
+            #else
+                if(std::strncmp(s_lhs.c_str(), s_rhs.c_str(), length))
+                    bind_len_or_null_[param][i] = parameter_size;
+            #endif
         }
     }
     else if(nulls)
@@ -2291,7 +2277,7 @@ private:
         for(SQLSMALLINT i = 0; i < n_columns; ++i)
         {
             NANODBC_CALL_RC(
-                NANODBC_UNICODE(SQLDescribeCol)
+                NANODBC_FUNC(SQLDescribeCol)
                 , rc
                 , stmt_.native_statement_handle()
                 , i + 1
@@ -2458,11 +2444,11 @@ inline void result::result_impl::get_ref_impl<date>(short column, date& result) 
     switch(col.ctype_)
     {
         case SQL_C_DATE:
-            result = *((date*)(col.pdata_ + rowset_position_ * col.clen_));
+            result = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
             return;
         case SQL_C_TIMESTAMP:
         {
-            timestamp stamp = *( (timestamp*)( col.pdata_ + rowset_position_ * col.clen_ ) );
+            timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_ );
             date d = { stamp.year, stamp.month, stamp.day };
             result = d;
             return;
@@ -2479,13 +2465,13 @@ inline void result::result_impl::get_ref_impl<timestamp>(short column, timestamp
     {
         case SQL_C_DATE:
         {
-            date d = *((date*)(col.pdata_ + rowset_position_ * col.clen_));
+            date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
             timestamp stamp = { d.year, d.month, d.day, 0, 0, 0, 0 };
             result = stamp;
             return;
         }
         case SQL_C_TIMESTAMP:
-            result = *((timestamp*)(col.pdata_ + rowset_position_ * col.clen_));
+            result = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
             return;
     }
     throw type_incompatible_error();
@@ -2503,8 +2489,8 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         {
             if(col.blob_)
             {
-                // Input is always std::string, while output may be std::string or std::wstring
-                std::stringstream ss;
+                // Input is always std::string, while output may be std::string or std::u16string
+                std::string out;
                 char buff[1024] = {0};
                 std::size_t buff_size = sizeof(buff);
                 SQLLEN ValueLenOrInd;
@@ -2522,11 +2508,11 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         , buff_size         // BufferLength
                         , &ValueLenOrInd);  // StrLen_or_IndPtr
                     if(ValueLenOrInd > 0)
-                        ss << buff;
+                        out.append(buff);
                     else if(ValueLenOrInd == SQL_NULL_DATA)
                         *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
                 } while(rc > 0);
-                convert(ss.str(), result);
+                convert(out, result);
             }
             else
             {
@@ -2541,10 +2527,10 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
         {
             if(col.blob_)
             {
-                // Input is always std::wstring, output might be std::string or std::wstring.
+                // Input is always std::u16string, output might be std::string or std::u16string.
                 // Use a string builder to build the output string.
-                std::wstringstream ss;
-                wchar_t buffer[512] = {0};
+                std::u16string out;
+                char16_t buffer[512] = {0};
                 std::size_t buffer_size = sizeof(buffer);
                 SQLLEN ValueLenOrInd;
                 SQLRETURN rc;
@@ -2561,18 +2547,18 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         , buffer_size       // BufferLength
                         , &ValueLenOrInd);  // StrLen_or_IndPtr
                     if(ValueLenOrInd > 0)
-                        ss << buffer;
+                        out.append(buffer);
                     else if(ValueLenOrInd == SQL_NULL_DATA)
                         *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
                 } while(rc > 0);
-                convert(ss.str(), result);
+                convert(out, result);
             }
             else
             {
                 // Type is unicode in the database, convert if necessary
                 const SQLWCHAR* s = reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
                 const string_type::size_type str_size = *col.cbdata_ / sizeof(SQLWCHAR);
-                std::wstring temp(s, s + str_size);
+                std::u16string temp(s, s + str_size);
                 convert(temp, result);
             }
             return;
@@ -2590,81 +2576,107 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
         case SQL_C_LONG:
         {
-           result.resize(column_size);
-           if(NANODBC_SNPRINTF(
-                    const_cast<string_type::value_type*>(result.data())
-                    , column_size
-                    , NANODBC_TEXT("%d")
-                    , *(int32_t*)(col.pdata_ + rowset_position_ * col.clen_)) == -1)
-               throw type_incompatible_error();
-           result.resize(NANODBC_STRLEN(result.c_str()));
-           return;
+            std::string buffer;
+            buffer.reserve(column_size + 1); // ensure terminating null
+            buffer.resize(buffer.capacity());
+            using std::fill;
+            fill(buffer.begin(), buffer.end(), '\0');
+            const int32_t data = *reinterpret_cast<int32_t*>(col.pdata_ + rowset_position_ * col.clen_);
+            const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size, "%d", data);
+            if(bytes == -1)
+                throw type_incompatible_error();
+            else if((SQLULEN)bytes < column_size)
+                buffer.resize(bytes);
+            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
+            result.reserve(buffer.size() * sizeof(string_type::value_type));
+            convert(buffer, result);
+            return;
         }
 
         case SQL_C_SBIGINT:
         {
             using namespace std; // in case intmax_t is in namespace std
-            result.resize(column_size);
-            if(NANODBC_SNPRINTF(
-                    const_cast<string_type::value_type*>(result.data())
-                    , column_size
-                    , NANODBC_TEXT("%jd")
-                    , (intmax_t) *(int64_t*)(col.pdata_ + rowset_position_ * col.clen_)) == -1)
+            std::string buffer;
+            buffer.reserve(column_size + 1); // ensure terminating null
+            buffer.resize(buffer.capacity());
+            using std::fill;
+            fill(buffer.begin(), buffer.end(), '\0');
+            const intmax_t data = (intmax_t)*reinterpret_cast<int64_t*>(col.pdata_ + rowset_position_ * col.clen_);
+            const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size, "%jd", data);
+            if(bytes == -1)
                 throw type_incompatible_error();
-            result.resize(NANODBC_STRLEN(result.c_str()));
+            else if((SQLULEN)bytes < column_size)
+                buffer.resize(bytes);
+            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
+            result.reserve(buffer.size() * sizeof(string_type::value_type));
+            convert(buffer, result);
             return;
         }
 
         case SQL_C_FLOAT:
         {
-            result.resize(column_size);
-            if(NANODBC_SNPRINTF(
-                    const_cast<string_type::value_type*>(result.data())
-                    , column_size
-                    , NANODBC_TEXT("%f")
-                    , *(float*)(col.pdata_ + rowset_position_ * col.clen_)) == -1)
+            std::string buffer;
+            buffer.reserve(column_size + 1); // ensure terminating null
+            buffer.resize(buffer.capacity());
+            using std::fill;
+            fill(buffer.begin(), buffer.end(), '\0');
+            const float data = *reinterpret_cast<float*>(col.pdata_ + rowset_position_ * col.clen_);
+            const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size, "%f", data);
+            if(bytes == -1)
                 throw type_incompatible_error();
-            result.resize(NANODBC_STRLEN(result.c_str()));
+            else if((SQLULEN)bytes < column_size)
+                buffer.resize(bytes);
+            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
+            result.reserve(buffer.size() * sizeof(string_type::value_type));
+            convert(buffer, result);
             return;
         }
 
         case SQL_C_DOUBLE:
         {
-            result.resize(column_size + 2);     // account for decimal mark and sign
-            if(NANODBC_SNPRINTF(
-                const_cast<string_type::value_type*>(result.data())
-                , column_size + 2
-                , NANODBC_TEXT("%.*lf")         // restrict the number of digits
+            std::string buffer;
+            const SQLULEN width = column_size + 2; // account for decimal mark and sign
+            buffer.reserve(width + 1); // ensure terminating null
+            buffer.resize(buffer.capacity());
+            using std::fill;
+            fill(buffer.begin(), buffer.end(), '\0');
+            const double data = *reinterpret_cast<double*>(col.pdata_ + rowset_position_ * col.clen_);
+            printf("data: %.*lf\n", col.scale_, data);
+            const int bytes = std::snprintf(
+                const_cast<char*>(buffer.data())
+                , width
+                , "%.*lf"                       // restrict the number of digits
                 , col.scale_                    // number of digits after the decimal point
-                , *(double*)(col.pdata_ + rowset_position_ * col.clen_)) == -1)
-            throw type_incompatible_error();
-            result.resize(NANODBC_STRLEN(result.c_str()));
+                , data);
+            if(bytes == -1)
+                throw type_incompatible_error();
+            else if((SQLULEN)bytes < column_size)
+                buffer.resize(bytes);
+            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
+            result.reserve(buffer.size() * sizeof(string_type::value_type));
+            convert(buffer, result);
             return;
         }
 
         case SQL_C_DATE:
         {
-            date d = *((date*)(col.pdata_ + rowset_position_ * col.clen_));
+            const date d = *reinterpret_cast<date*>(col.pdata_ + rowset_position_ * col.clen_);
             std::tm st = { 0 };
             st.tm_year = d.year - 1900;
             st.tm_mon = d.month - 1;
             st.tm_mday = d.day;
             char* old_lc_time = std::setlocale(LC_TIME, NULL);
             std::setlocale(LC_TIME, "");
-            string_type::value_type date_str[512];
-            NANODBC_STRFTIME(
-                date_str
-                , sizeof(date_str) / sizeof(string_type::value_type)
-                , NANODBC_TEXT("%Y-%m-%d")
-                , &st);
+            char date_str[512];
+            std::strftime(date_str, sizeof(date_str), "%Y-%m-%d", &st);
             std::setlocale(LC_TIME, old_lc_time);
-            result.assign(date_str);
+            convert(date_str, result);
             return;
         }
 
         case SQL_C_TIMESTAMP:
         {
-            timestamp stamp = *((timestamp*)(col.pdata_ + rowset_position_ * col.clen_));
+            const timestamp stamp = *reinterpret_cast<timestamp*>(col.pdata_ + rowset_position_ * col.clen_);
             std::tm st = { 0 };
             st.tm_year = stamp.year - 1900;
             st.tm_mon = stamp.month - 1;
@@ -2674,15 +2686,11 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
             st.tm_sec = stamp.sec;
             char* old_lc_time = std::setlocale(LC_TIME, NULL);
             std::setlocale(LC_TIME, "");
-            string_type::value_type date_str[512];
-            NANODBC_STRFTIME(
-                date_str
-                , sizeof(date_str) / sizeof(string_type::value_type)
-                , NANODBC_TEXT("%Y-%m-%d %H:%M:%S %z")
-                , &st);
+            char date_str[512];
+            std::strftime(date_str, sizeof(date_str), "%Y-%m-%d %H:%M:%S %z", &st);
             std::setlocale(LC_TIME, old_lc_time);
-           result.assign(date_str);
-           return;
+            convert(date_str, result);
+            return;
         }
     }
     throw type_incompatible_error();
@@ -3543,7 +3551,7 @@ catalog::tables catalog::find_tables(
     statement stmt(conn_);
     RETCODE rc;
     NANODBC_CALL_RC(
-        NANODBC_UNICODE(SQLTables)
+        NANODBC_FUNC(SQLTables)
         , rc
         , stmt.native_statement_handle()
         , (NANODBC_SQLCHAR*)(catalog.empty() ? NULL : catalog.c_str())
@@ -3570,7 +3578,7 @@ catalog::columns catalog::find_columns(
     statement stmt(conn_);
     RETCODE rc;
     NANODBC_CALL_RC(
-        NANODBC_UNICODE(SQLColumns)
+        NANODBC_FUNC(SQLColumns)
         , rc
         , stmt.native_statement_handle()
         , (NANODBC_SQLCHAR*)(catalog.empty() ? NULL : catalog.c_str())
@@ -3596,7 +3604,7 @@ catalog::primary_keys catalog::find_primary_keys(
     statement stmt(conn_);
     RETCODE rc;
     NANODBC_CALL_RC(
-        NANODBC_UNICODE(SQLPrimaryKeys)
+        NANODBC_FUNC(SQLPrimaryKeys)
         , rc
         , stmt.native_statement_handle()
         , (NANODBC_SQLCHAR*)(catalog.empty() ? NULL : catalog.c_str())

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -130,7 +130,7 @@ namespace nanodbc
 // You must explicitly request Unicode support by defining NANODBC_USE_UNICODE at compile time.
 #ifndef DOXYGEN
     #ifdef NANODBC_USE_UNICODE
-        typedef std::wstring string_type;
+        typedef std::u16string string_type;
     #else
         typedef std::string string_type;
     #endif // NANODBC_USE_UNICODE
@@ -146,7 +146,7 @@ namespace nanodbc
         typedef long null_type;
     #endif
 #else
-    //! string_type will be std::wstring if NANODBC_USE_UNICODE is defined, otherwise std::string.
+    //! string_type will be std::u16string if NANODBC_USE_UNICODE is defined, otherwise std::string.
     typedef unspecified-type string_type;
     //! null_type will be int64_t for 64-bit compilations, otherwise long.
     typedef unspecified-type null_type;

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -107,8 +107,14 @@ struct base_test_fixture
                 return utf_to_utf<char16_t>(connection_string.c_str()
                     , connection_string.c_str() + connection_string.size());
             #else
+                #if defined(_MSC_VER) && (_MSC_VER == 1900)
+            auto s = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(connection_string);
+            auto p = reinterpret_cast<char16_t const*>(s.data());
+            return nanodbc::string_type(p, p + s.size());
+                #else
                 return std::wstring_convert<
                     std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(connection_string);
+                #endif
             #endif
         #else
                 return connection_string;

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef NANODBC_USE_UNICODE
-    #define NANODBC_TEXT(s) L ## s
+    #define NANODBC_TEXT(s) u ## s
 #else
     #define NANODBC_TEXT(s) s
 #endif
@@ -104,11 +104,11 @@ struct base_test_fixture
         #ifdef NANODBC_USE_UNICODE
             #ifdef NANODBC_USE_BOOST_CONVERT
                 using boost::locale::conv::utf_to_utf;
-                return utf_to_utf<wchar_t>(
-                    connection_string.c_str()
+                return utf_to_utf<char16_t>(connection_string.c_str()
                     , connection_string.c_str() + connection_string.size());
             #else
-                return std::wstring_convert<std::codecvt_utf8<wchar_t>>().from_bytes(connection_string);
+                return std::wstring_convert<
+                    std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(connection_string);
             #endif
         #else
                 return connection_string;
@@ -680,17 +680,25 @@ struct base_test_fixture
             // or -1 if the number of affected rows is not available.
             // For other statements and functions, the driver may define the value returned (...)
             // some data sources may be able to return the number of rows returned by a SELECT statement.
-            // REQUIRE(results.affected_rows() == 4 || results.affected_rows() == 0 || results.affected_rows() == -1);
             const bool affected_four = results.affected_rows() == 4;
             const bool affected_zero = results.affected_rows() == 0;
             const bool affected_negative_one = results.affected_rows() == -1;
             REQUIRE(affected_four + affected_zero + affected_negative_one);
+            if(!(affected_four + affected_zero + affected_negative_one)) {
+                // Provide more verbose output if one of the above terms is false:
+                CHECK(affected_four);
+                CHECK(affected_zero);
+                CHECK(affected_negative_one);
+            }
 
             REQUIRE(results.rowset_size() == 1);
             REQUIRE(results.column_name(0) == NANODBC_TEXT("a"));
             REQUIRE(results.column_name(1) == NANODBC_TEXT("b"));
 
+            // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             REQUIRE(results.next());
+            // row = (null)|z
+            // .....................................................................................
             REQUIRE(results.rows() == 1);
             REQUIRE(results.is_null(0));
             REQUIRE(results.is_null(NANODBC_TEXT("a")));
@@ -713,7 +721,10 @@ struct base_test_fixture
             results.get_ref<nanodbc::string_type>(NANODBC_TEXT("a"), NANODBC_TEXT("null2"), ref_str);
             REQUIRE(ref_str == NANODBC_TEXT("null2"));
 
+            // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             REQUIRE(results.next());
+            // row = 1|one
+            // .....................................................................................
             REQUIRE(results.get<int>(0) == 1);
             REQUIRE(results.get<int>(NANODBC_TEXT("a")) == 1);
             REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("one"));
@@ -721,7 +732,10 @@ struct base_test_fixture
 
             nanodbc::result results_copy = results;
 
+            // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             REQUIRE(results_copy.next());
+            // row = 2|two
+            // .....................................................................................
             REQUIRE(results_copy.get<int>(0, -1) == 2);
             REQUIRE(results_copy.get<int>(NANODBC_TEXT("a"), -1) == 2);
             REQUIRE(results_copy.get<nanodbc::string_type>(1) == NANODBC_TEXT("two"));
@@ -733,7 +747,10 @@ struct base_test_fixture
 
             nanodbc::result().swap(results_copy);
 
+            // :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
             REQUIRE(results.next());
+            // row = 3|tri
+            // .....................................................................................
             REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("3"));
             REQUIRE(results.get<nanodbc::string_type>(NANODBC_TEXT("a")) == NANODBC_TEXT("3"));
             REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("tri"));

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -34,24 +34,6 @@ namespace
         {
             std::remove("nanodbc.db");
         }
-
-        // SQLite prior to version 3.3 does not support `DROP TABLE IF EXISTS` syntax.
-        void drop_table(nanodbc::connection& connection, const nanodbc::string_type& name) const NANODBC_OVERRIDE
-        {
-            // NOTE: Define USE_DROP_TABLE_IF_EXISTS_WORKAROUND when testing against SQLite <3.3.
-            #ifdef USE_DROP_TABLE_IF_EXISTS_WORKAROUND
-                nanodbc::result results = execute(connection,
-                    NANODBC_TEXT("SELECT COUNT(1) ")
-                    NANODBC_TEXT("FROM sqlite_master ")
-                    NANODBC_TEXT("WHERE type='table' AND ")
-                    NANODBC_TEXT("name='") + name +
-                    NANODBC_TEXT("';"));
-                if(results.next() && results.get<int>(0))
-                    execute(connection, NANODBC_TEXT("DROP TABLE ") + name + NANODBC_TEXT(";"));
-            #else
-                execute(connection, NANODBC_TEXT("DROP TABLE IF EXISTS ") + name + NANODBC_TEXT(";"));
-            #endif
-        }
     };
 }
 


### PR DESCRIPTION
Attempt to use of `std::wstring_convert` with `char16_t` causes linker errors due to [bug confirmed in VS2015](https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error) (including Update 1).

This patch applies workaround specific to VS2015, based on intermediate casting of string elements to/from `int16_t`.

Fixes PR #96.