### PR TITLE
Enable iODBC + Unicode support with `u32string` types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if(UNIX)
 			set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
 			execute_process(COMMAND ${ODBC_CONFIG} --libs
 				OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
+			if(NANODBC_USE_UNICODE)
+				add_definitions(-DNANODBC_USE_IODBC_WIDE_STRINGS)
+			endif()
 		endif()
 	endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ubuntu:latest
-# RUN DEBIAN_FRONTEND=noninteractive apt-get -qqy update
+# RUN DEBIAN_FRONTEND=noninteractive apt-get -qqy update \
 #  && DEBIAN_FRONTEND=noninteractive apt-get -qqy install software-properties-common
 
 # travis-ci unit tests run using ubuntu:precise, but development is often
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qqy \
 RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qqy \
  && DEBIAN_FRONTEND=noninteractive apt-get -qqy install \
-        $(apt-cache -q search "libboost-locale1\..*-dev" | awk '{print $1}') \
+        $(apt-cache -q search "libboost-locale1\..*-dev" | awk '{print $1}' | sort -nr | head -n 1) \
         cmake \
         doxygen \
         g++-5 \
@@ -28,10 +28,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qqy \
 
 # Might not be available, but install it if it is.
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install jekyll || true
-
-# Cleanup so image is smaller
-RUN DEBIAN_FRONTEND=noninteractive apt-get clean \
- && rm -rf /var/lib/apt/lists/*
 
 RUN odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini
 RUN odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -112,14 +112,14 @@ namespace nanodbc
     //! \brief Assertion.
     //!
     //! By default, nanodbc uses C \c assert() for internal assertions.
-    //! User can override it by defining NANODBC_ASSERT(expr) macro
+    //! User can override it by defining \c NANODBC_ASSERT(expr) macro
     //! in the nanodbc.h file and customizing it as desired,
     //! before building the library.
     //!
     //! \code{.cpp}
     //! #ifdef _DEBUG
-    //! #include <crtdbg.h>
-    //! #define NANODBC_ASSERT _ASSERTE
+    //!     #include <crtdbg.h>
+    //!     #define NANODBC_ASSERT _ASSERTE
     //! #endif
     //! \endcode
     #define NANODBC_ASSERT(expression) assert(expression)
@@ -130,30 +130,34 @@ namespace nanodbc
 // You must explicitly request Unicode support by defining NANODBC_USE_UNICODE at compile time.
 #ifndef DOXYGEN
     #ifdef NANODBC_USE_UNICODE
-        typedef std::u16string string_type;
+        #ifdef NANODBC_USE_IODBC_WIDE_STRINGS
+            typedef std::u32string string_type;
+        #else
+            typedef std::u16string string_type;
+        #endif
     #else
         typedef std::string string_type;
     #endif // NANODBC_USE_UNICODE
 
     #if defined(_WIN64)
-        // LLP64 machine, Windows
+        // LLP64 machine: Windows
         typedef std::int64_t null_type;
     #elif !defined(_WIN64) && defined(__LP64__)
-        // LP64 machine, OS X or Linux
+        // LP64 machine: OS X or Linux
         typedef long null_type;
     #else
         // 32-bit machine
         typedef long null_type;
     #endif
 #else
-    //! string_type will be std::u16string if NANODBC_USE_UNICODE is defined, otherwise std::string.
+    //! \c string_type will be \c std::u16string or \c std::32string if \c NANODBC_USE_UNICODE is defined, otherwise \c std::string.
     typedef unspecified-type string_type;
-    //! null_type will be int64_t for 64-bit compilations, otherwise long.
+    //! \c null_type will be \c int64_t for 64-bit compilations, otherwise \c long.
     typedef unspecified-type null_type;
 #endif // DOXYGEN
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
-    // These versions of Visual C++ do not yet support noexcept or std::move.
+    // These versions of Visual C++ do not yet support \c noexcept or \c std::move.
     #define NANODBC_NOEXCEPT
     #define NANODBC_NO_MOVE_CTOR
 #else
@@ -176,10 +180,10 @@ namespace nanodbc
 //! \addtogroup exceptions Exception types
 //! \brief Possible error conditions.
 //!
-//! Specific errors such as type_incompatible_error, null_access_error, and index_range_error can arise
-//! from improper use of the nanodbc library. The general database_error is for all other situations
+//! Specific errors such as \c type_incompatible_error, \c null_access_error, and \c index_range_error can arise
+//! from improper use of the nanodbc library. The general \c database_error is for all other situations
 //! in which the ODBC driver or C API reports an error condition. The explanatory string for database_error
-//! will, if possible, contain a diagnostic message obtained from SQLGetDiagRec().
+//! will, if possible, contain a diagnostic message obtained from \c SQLGetDiagRec().
 //! @{
 
 //! \brief Type incompatible.


### PR DESCRIPTION
Simple fix for when iODBC + Unicode build is detected. Doesn't resolve #111, though I'm not entierly convinced that #111 isn't just caused by the fact that `libsqliteodbc` isn't built against iODBC.