### PR TITLE
Use NANODBC_CODECVT_TYPE with unsigned short for Visual C++ 1900.

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -209,10 +209,11 @@ namespace
             out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
         #else
             #if defined(_MSC_VER) && (_MSC_VER == 1900)
-                // Workaround for confirmed bug in VS2015.
-                // See: https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
-                auto p = reinterpret_cast<wide_char_t const*>(in.data());
-                out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(p, p + in.size());
+                // Workaround for confirmed bug in VS2015. See:
+                // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
+                // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+                auto p = reinterpret_cast<unsigned short const*>(in.data());
+                out = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().to_bytes(p, p + in.size());
             #else
                 out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(in);
             #endif
@@ -226,9 +227,10 @@ namespace
                 using boost::locale::conv::utf_to_utf;
                 out = utf_to_utf<wide_char_t>(in.c_str(), in.c_str() + in.size());
             #elif defined(_MSC_VER) && (_MSC_VER == 1900)
-                // Workaround for confirmed bug in VS2015.
-                // See: https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
-                auto s = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().from_bytes(in);
+                // Workaround for confirmed bug in VS2015. See:
+                // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
+                // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+                auto s = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().from_bytes(in);
                 auto p = reinterpret_cast<wide_char_t const*>(s.data());
                 out.assign(p, p + s.size());
             #else


### PR DESCRIPTION
In VS2013, `char16_t` was a typedef of `unsigned int`.
In VS2015, `char16_t` is a distinct type of it's own.
Switching `char16_t` to `unsigned short` should get the old
behavior from earlier versions and fix the missing export error.
See https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302

Fixes #121