### PR TITLE
Prevent Travs CI from building topic branches without PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - latest
+    - release
 addons:
   apt:
     sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ platform: x64
 
 configuration: Release
 
+branches:
+  only:
+    - master
+    - latest
+    - release
+
 matrix:
   fast_finish: false # set this flag to immediately finish build once one of the jobs fails.
 


### PR DESCRIPTION
I believe this should prevent Travis CI from building anything except for the specific branches listed and pull requests. We won't get builds for topic branches anymore, which I think is fine. To initiate a build we'll have to open a PR.