### PR TITLE
Fix overflowing transaction counter

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -994,15 +994,16 @@ public:
         return string_type(&name[0], &name[strarrlen(name)]);
     }
 
-
     std::size_t ref_transaction()
     {
-        return --transactions_;
+        return ++transactions_;
     }
 
     std::size_t unref_transaction()
     {
-        return ++transactions_;
+        if(transactions_ > 0)
+            --transactions_;
+        return transactions_;
     }
 
     bool rollback() const

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -327,7 +327,7 @@ public:
     //! \brief If this transaction has not been committed, will will rollback any modifying operations.
     ~transaction() NANODBC_NOEXCEPT;
 
-    //! \brief Marks this transaction for commit.
+    //! \brief Commits transaction immediately.
     //! \throws database_error
     void commit();
 


### PR DESCRIPTION
Correct mixed up definitions of ref_/unref_transaction.
Update transaction test to track the counter value.

Fixes #143 
