### PR TITLE
Add test for PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ addons:
       - libmyodbc
       - libsqliteodbc
       - mysql-client
+      - odbc-postgresql
       - unixodbc
       - unixodbc-dev
 services:
   - mysql
+  - postgresql
 language: cpp
 compiler:
   - gcc
@@ -27,24 +29,33 @@ env:
   - DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
   - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
   - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+  #TODO: - DB=postgresql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
   - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
   - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
   - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=ON
   - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=ON
 before_install:
-  - if [[ "$DB" == "sqlite" ]]; then sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini; fi
+  - if [[ -f /etc/odbcinst.ini ]]; then export ODBCSYSINI=/etc; fi
+  - if [[ -f /etc/odbc.ini ]]; then export ODBCINI=/etc/odbc.ini; fi
   - if [[ "$DB" == "mysql" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "DROP DATABASE IF EXISTS nanodbc_tests; CREATE DATABASE IF NOT EXISTS nanodbc_tests;" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost';" -uroot; fi
   - if [[ "$DB" == "mysql" ]]; then export NANODBC_TEST_CONNSTR="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
+  - if [[ "$DB" == "postgresql" ]]; then sudo odbcinst -i -d -f /usr/share/psqlodbc/odbcinst.ini.template; fi
+  - if [[ "$DB" == "postgresql" ]]; then psql -c "CREATE DATABASE nanodbc_tests;" -U postgres; fi
+  - if [[ "$DB" == "postgresql" ]]; then export NANODBC_TEST_CONNSTR="Driver={PostgreSQL ANSI};Server=127.0.0.1;Port=5432;Database=nanodbc_tests;UID=postgres;"; fi
+  - if [[ "$DB" == "sqlite" ]]; then sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini; fi
 before_script:
-  - if [[ -f /etc/odbc.ini ]]; then cat /etc/odbc.ini; fi
-  - if [[ -f /etc/odbcinst.ini ]]; then cat /etc/odbcinst.ini; fi
+  - odbcinst -j
+  - if [[ -f "$ODBCSYSINI/odbcinst.ini" ]]; then odbcinst -q -d; fi
+  - if [[ -s "$ODBCINI" ]]; then odbcinst -q -s; fi
   - export CXX="g++-5"
 script:
   - mkdir build
   - cd build
   - cmake -D NANODBC_USE_UNICODE=${USE_UNICODE} -D NANODBC_USE_BOOST_CONVERT=${USE_BOOST_CONVERT} -D NANODBC_HANDLE_NODATA_BUG=${USE_NODATA_BUG} -D NANODBC_ENABLE_LIBCXX=NO ..
   - make
-  - if [[ "$DB" == "sqlite" ]]; then make VERBOSE=1 sqlite_check; fi
   - if [[ "$DB" == "mysql" ]]; then make VERBOSE=1 mysql_check; fi
+  #TODO: [unixODBC][Driver Manager]Data source name not found, and no default driver specified
+  #- if [[ "$DB" == "postgresql" ]]; then make VERBOSE=1 postgresql_check; fi
+  - if [[ "$DB" == "sqlite" ]]; then make VERBOSE=1 sqlite_check; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ test_script:
       }
       elseif ($env:DB -Match "PostgreSQL") {
         $env:NANODBC_TEST_CONNSTR="Driver={PostgreSQL ANSI(x64)};Server=127.0.0.1;Port=5432;Database=nanodbc_test;Uid=postgres;Pwd=Password12!;"
-        $test_name = "odbc_test"
+        $test_name = "postgresql_test"
       }
       else {
         throw 'TODO: ' + $env:DB + ' not configured yet'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${CATCH_INCLUDE_
 link_directories(${CMAKE_BINARY_DIR}/lib)
 file(GLOB headers *.h *.hpp)
 add_custom_target(tests DEPENDS tests catch)
-set(test_list mssql mysql odbc sqlite)
+set(test_list mssql mysql odbc postgresql sqlite)
 foreach(test_item ${test_list})
 	set(test_name ${test_item}_tests)
 	add_executable(${test_name} ${test_item}_test.cpp ${headers})

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -258,9 +258,20 @@ struct base_test_fixture
             REQUIRE(columns.column_name() == NANODBC_TEXT("c2"));
             REQUIRE(columns.sql_data_type() == SQL_FLOAT);
             if (columns.numeric_precision_radix() == 10)
-                REQUIRE(columns.column_size() ==  17); // total number of digits allowed
+            {
+                // total number of digits allowed
+
+                // NOTE: Some variations have been observed:
+                // Windows 64-bit + nanodbc 64-bit build + psqlODBC 9.?.? x64 connected to PostgreSQL 9.3 on Windows x64 (AppVeyor)
+                REQUIRE(columns.column_size() >= 15);
+                // Windows x64      + nanodbc 64-bit build + psqlODBC 9.3.5 x64 connected to PostgreSQL 9.5 on Ubuntu 15.10 x64 (Vagrant)
+                // Ubuntu 12.04 x64 + nanodbc 64-bit build + psqlODBC 9.3.5 x64 connected to PostgreSQL 9.1 on Ubuntu 12.04 x64 (Travsi CI)
+                REQUIRE(columns.column_size() <= 17);
+            }
             else
-                REQUIRE(columns.column_size() ==  53); // total number of bits allowed
+            {
+                REQUIRE(columns.column_size() == 53); // total number of bits allowed
+            }
             REQUIRE(columns.nullable() == SQL_NULLABLE);
             if (!columns.is_nullable().empty()) // nullability determined
                 REQUIRE(columns.is_nullable() == NANODBC_TEXT("YES"));

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -1,0 +1,103 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "test/base_test_fixture.h"
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+    struct postgresql_fixture : public base_test_fixture
+    {
+        postgresql_fixture()
+        : base_test_fixture(/* connecting string from NANODBC_TEST_CONNSTR environment variable)*/)
+        {
+        }
+
+        virtual ~postgresql_fixture() NANODBC_NOEXCEPT
+        {
+        }
+    };
+}
+
+// TODO: add blob (bytea) test
+
+TEST_CASE_METHOD(postgresql_fixture, "catalog_columns_test", "[postgresql][catalog][columns]")
+{
+    catalog_columns_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "catalog_primary_keys_test", "[postgresql][catalog][primary_keys]")
+{
+    catalog_primary_keys_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "catalog_tables_test", "[postgresql][catalog][tables]")
+{
+    catalog_tables_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "dbms_info_test", "[postgresql][dmbs][metadata][info]")
+{
+    dbms_info_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "decimal_conversion_test", "[postgresql][decimal][conversion]")
+{
+    decimal_conversion_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "exception_test", "[postgresql][exception]")
+{
+    exception_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "execute_multiple_transaction_test", "[postgresql][execute][transaction]")
+{
+    execute_multiple_transaction_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "execute_multiple_test", "[postgresql][execute]")
+{
+    execute_multiple_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "integral_test", "[postgresql][integral]")
+{
+    integral_test<postgresql_fixture>();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "move_test", "[postgresql][move]")
+{
+    move_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "null_test", "[postgresql][null]")
+{
+    null_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "simple_test", "[postgresql]")
+{
+    simple_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "string_test", "[postgresql][string]")
+{
+    string_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "transaction_test", "[postgresql][transaction]")
+{
+    transaction_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "while_not_end_iteration_test", "[postgresql][looping]")
+{
+    while_not_end_iteration_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "while_next_iteration_test", "[postgresql][looping]")
+{
+    while_next_iteration_test();
+}


### PR DESCRIPTION
Set up PostgreSQL testing on Travis CI and AppVeyor.
Comment on `SQL_FLOAT` column size (15 or 17 digits) observed in different environments.

------

As pointed in https://github.com/lexicalunit/nanodbc/pull/130#issuecomment-217127673, generic `odbc_test.cpp` serves more as an example and we still need to maintain sets of DBMS-specific test cases.