### PR TITLE
Pass correct buffer size to SQLGetData.

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2556,10 +2556,10 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         , column + 1        // Col_or_Param_Num
                         , col.ctype_        // TargetType
                         , buffer            // TargetValuePtr
-                        , buffer_size - 1   // BufferLength
+                        , buffer_size       // BufferLength
                         , &ValueLenOrInd);  // StrLen_or_IndPtr
                     if(ValueLenOrInd > 0)
-                        out.append(buffer, std::min<std::size_t>(ValueLenOrInd, buffer_size - 1));
+                        out.append(buffer, std::min<std::size_t>(ValueLenOrInd, col.ctype_ == SQL_C_BINARY ? buffer_size : buffer_size - 1));
                     else if(ValueLenOrInd == SQL_NULL_DATA)
                         *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
                     // Sequence of successful calls is:
@@ -2603,7 +2603,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                         , column + 1        // Col_or_Param_Num
                         , col.ctype_        // TargetType
                         , buffer            // TargetValuePtr
-                        , buffer_size - 1   // BufferLength
+                        , buffer_size       // BufferLength
                         , &ValueLenOrInd);  // StrLen_or_IndPtr
                     if(ValueLenOrInd > 0)
                         out.append(buffer, std::min<std::size_t>(ValueLenOrInd, buffer_size - 1));


### PR DESCRIPTION
I was getting spurious null bytes in the middle of any CLOB longer than 1023 bytes returned from result::get, when using SQL Server ODBC Driver 11 on Windows 8. This PR fixes that.

However, I just realized that I'm basically reverting part of this commit:

https://github.com/lexicalunit/nanodbc/commit/8dbfc45bce465db3101fd8d9d009e882461483d7

Looking at the ODBC documentation it seems clear that the correct usage is to pass the actual length of the buffer, but presumably the change in the above commit was made for a reason. Is it possible CLOBs and BLOBs need different handling here?

EDIT: Yes, CLOBs have the null byte while BLOBs don't, so with the current behavior of returning binary data as string, an additional check was needed to avoid removing a byte of real binary data. The commit has been amended accordingly.