### PR TITLE
Add MariaDB to Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,105 @@
+language: cpp
+
 branches:
   only:
     - master
     - latest
     - release
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - g++-5
-      - libboost-locale1.55-dev
-      - libmyodbc
-      - libsqliteodbc
-      - mysql-client
-      - odbc-postgresql
-      - unixodbc
-      - unixodbc-dev
-services:
-  - mysql
-  - postgresql
-language: cpp
-compiler:
-  - gcc
-env:
-  - DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
-  - DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
-  - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
-  - DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
-  - DB=postgresql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
-  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
-  - DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
-  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=ON
-  - DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=ON
-before_install:
+
+before_script:
   - if [[ -f /etc/odbcinst.ini ]]; then export ODBCSYSINI=/etc; fi
   - if [[ -f /etc/odbc.ini ]]; then export ODBCINI=/etc/odbc.ini; fi
-  - if [[ "$DB" == "mysql" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
-  - if [[ "$DB" == "mysql" ]]; then mysql -e "DROP DATABASE IF EXISTS nanodbc_tests; CREATE DATABASE IF NOT EXISTS nanodbc_tests;" -uroot; fi
-  - if [[ "$DB" == "mysql" ]]; then mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost';" -uroot; fi
-  - if [[ "$DB" == "mysql" ]]; then export NANODBC_TEST_CONNSTR="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "DROP DATABASE IF EXISTS nanodbc_tests; CREATE DATABASE IF NOT EXISTS nanodbc_tests;" -uroot; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost';" -uroot; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then export NANODBC_TEST_CONNSTR="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
   - if [[ "$DB" == "postgresql" ]]; then sudo odbcinst -i -d -f /usr/share/psqlodbc/odbcinst.ini.template; fi
   - if [[ "$DB" == "postgresql" ]]; then psql -c "CREATE DATABASE nanodbc_tests;" -U postgres; fi
   - if [[ "$DB" == "postgresql" ]]; then export NANODBC_TEST_CONNSTR="DRIVER={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc_tests;UID=postgres;"; fi
   - if [[ "$DB" == "sqlite" ]]; then sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini; fi
-before_script:
   - odbcinst -j
   - if [[ -f "$ODBCSYSINI/odbcinst.ini" ]]; then odbcinst -q -d; fi
   - if [[ -s "$ODBCINI" ]]; then odbcinst -q -s; fi
   - export CXX="g++-5"
+
 script:
   - mkdir build
   - cd build
   - cmake -D NANODBC_USE_UNICODE=${USE_UNICODE} -D NANODBC_USE_BOOST_CONVERT=${USE_BOOST_CONVERT} -D NANODBC_HANDLE_NODATA_BUG=${USE_NODATA_BUG} -D NANODBC_ENABLE_LIBCXX=NO ..
   - make
-  - if [[ "$DB" == "mysql" ]]; then make VERBOSE=1 mysql_check; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then make VERBOSE=1 mysql_check; fi
   - if [[ "$DB" == "postgresql" ]]; then make VERBOSE=1 postgresql_check; fi
   - if [[ "$DB" == "sqlite" ]]; then make VERBOSE=1 sqlite_check; fi
+
+matrix:
+  include:
+    - env: DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: &mysql
+        mysql: "5.5"
+        apt:
+          sources: &sources
+            - ubuntu-toolchain-r-test
+            - boost-latest
+          packages:
+            - g++-5
+            - libboost-locale1.55-dev
+            - unixodbc
+            - unixodbc-dev
+            - libmyodbc
+            - mysql-client
+    - env: DB=mysql USE_UNICODE=OFF  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: *mysql
+    - env: DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: *mysql
+    - env: DB=mysql USE_UNICODE=ON   USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: *mysql
+    - env: DB=postgresql USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: &postgresql
+        postgresql: "9.1"
+        apt:
+          sources: *sources
+          packages:
+            - g++-5
+            - libboost-locale1.55-dev
+            - unixodbc
+            - unixodbc-dev
+            - odbc-postgresql
+    - env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: &sqlite
+        apt:
+          sources: *sources
+          packages:
+            - g++-5
+            - libboost-locale1.55-dev
+            - unixodbc
+            - unixodbc-dev
+            - libsqliteodbc
+    - env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON  USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons: *sqlite
+    - env: DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=ON
+      compiler: gcc
+      addons: *sqlite
+    - env: DB=sqlite USE_UNICODE=ON  USE_BOOST_CONVERT=ON  USE_NODATA_BUG=ON
+      compiler: gcc
+      addons: *sqlite
+    - env: DB=mariadb USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF
+      compiler: gcc
+      addons:
+        mariadb: "10.0"
+        apt:
+          sources: *sources
+          packages:
+            - g++-5
+            - libboost-locale1.55-dev
+            - unixodbc
+            - unixodbc-dev
+            - libmyodbc
+  allow_failures:
+    - env: DB=mariadb USE_UNICODE=OFF  USE_BOOST_CONVERT=OFF USE_NODATA_BUG=OFF


### PR DESCRIPTION

The Travis CI docs on `env` vs `matrix` with `addons` setup might be obscure, so here are good examples of `.travis.yml` to follow:

- https://github.com/doctrine/doctrine2
- https://github.com/Microsoft/GSL
- https://github.com/genbattle/dkm