### PR TITLE
Add DB-specific tests for result::affected_rows

### DIFF
--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -22,6 +22,48 @@ namespace
 
 // FIXME: No catlog_* tests for MySQL. Not supported?
 
+TEST_CASE_METHOD(mysql_fixture, "affected_rows_test", "[mysql][affected_rows]")
+{
+    nanodbc::connection conn = connect();
+
+    // CREATE DATABASE|TABLE
+    {
+        execute(conn, NANODBC_TEXT("DROP DATABASE IF EXISTS nanodbc_test_temp_db"));
+        nanodbc::result result;
+        result = execute(conn, NANODBC_TEXT("CREATE DATABASE nanodbc_test_temp_db"));
+        REQUIRE(result.affected_rows() == 1);
+        execute(conn, NANODBC_TEXT("USE nanodbc_test_temp_db"));
+        result = execute(conn, NANODBC_TEXT("CREATE TABLE nanodbc_test_temp_table (i int)"));
+        REQUIRE(result.affected_rows() == 0);
+    }
+    // INSERT
+    {
+        nanodbc::result result;
+        result = execute(conn, NANODBC_TEXT("INSERT INTO nanodbc_test_temp_table VALUES (1)"));
+        REQUIRE(result.affected_rows() == 1);
+        result = execute(conn, NANODBC_TEXT("INSERT INTO nanodbc_test_temp_table VALUES (2)"));
+        REQUIRE(result.affected_rows() == 1);
+    }
+    // SELECT
+    {
+        auto result = execute(conn, NANODBC_TEXT("SELECT i FROM nanodbc_test_temp_table"));
+        REQUIRE(result.affected_rows() == 2);
+    }
+    // DELETE
+    {
+        auto result = execute(conn, NANODBC_TEXT("DELETE FROM nanodbc_test_temp_table"));
+        REQUIRE(result.affected_rows() == 2);
+    }
+    // DROP DATABASE|TABLE
+    {
+        nanodbc::result result;
+        result = execute(conn, NANODBC_TEXT("DROP TABLE nanodbc_test_temp_table"));
+        REQUIRE(result.affected_rows() == 0);
+        result = execute(conn, NANODBC_TEXT("DROP DATABASE nanodbc_test_temp_db"));
+        REQUIRE(result.affected_rows() == 0);
+    }
+}
+
 TEST_CASE_METHOD(mysql_fixture, "blob_test", "[mysql][blob]")
 {
     blob_test();


### PR DESCRIPTION
Covered for number of DBMS, should serve as documentation of differences in returned value between database/drive implementations.