### PR TITLE
Add input iterator for result class

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2063,7 +2063,7 @@ public:
         return static_cast<unsigned long>(pos) + rowset_position_;
     }
 
-    bool end() const NANODBC_NOEXCEPT
+    bool at_end() const NANODBC_NOEXCEPT
     {
         if(at_end_)
             return true;
@@ -3850,9 +3850,9 @@ unsigned long result::position() const
     return impl_->position();
 }
 
-bool result::end() const NANODBC_NOEXCEPT
+bool result::at_end() const NANODBC_NOEXCEPT
 {
-    return impl_->end();
+    return impl_->at_end();
 }
 
 bool result::is_null(short column) const

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -159,6 +159,11 @@ TEST_CASE_METHOD(mssql_fixture, "nullptr_nulls_test", "[mssql][null]")
     nullptr_nulls_test();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "rowset_iterator_test", "[mssql][iterator]")
+{
+    rowset_iterator_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "simple_test", "[mssql]")
 {
     simple_test();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -114,6 +114,11 @@ TEST_CASE_METHOD(mysql_fixture, "nullptr_nulls_test", "[mysql][null]")
     nullptr_nulls_test();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "rowset_iterator_test", "[mysql][iterator]")
+{
+    rowset_iterator_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "simple_test", "[mysql]")
 {
     simple_test();

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -85,6 +85,11 @@ TEST_CASE_METHOD(odbc_fixture, "nullptr_nulls_test", "[odbc][null]")
     nullptr_nulls_test();
 }
 
+TEST_CASE_METHOD(odbc_fixture, "rowset_iterator_test", "[odbc][iterator]")
+{
+    rowset_iterator_test();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "simple_test", "[odbc]")
 {
     simple_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -77,6 +77,11 @@ TEST_CASE_METHOD(postgresql_fixture, "null_test", "[postgresql][null]")
     null_test();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "rowset_iterator_test", "[postgresql][iterator]")
+{
+    rowset_iterator_test();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "simple_test", "[postgresql]")
 {
     simple_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -173,6 +173,11 @@ TEST_CASE_METHOD(sqlite_fixture, "nullptr_nulls_test", "[sqlite][null]")
     nullptr_nulls_test();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "rowset_iterator_test", "[sqlite][iterator]")
+{
+    rowset_iterator_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "simple_test", "[sqlite]")
 {
     simple_test();


### PR DESCRIPTION
The new `result_iterator` should enable C++ idiomatic iteration over rows of query results, also with range-based for loop.

Rename `result::end` to `result::at_end` to avoid name clash with a member `iterator end()` that prevents ADL to work for `nanodbc::begin/end` discovery.

-----

This is a very quickly cooked proposal inspired by question at the end of this https://github.com/lexicalunit/nanodbc/issues/146#issuecomment-217661815. Comments and reviews much appreciated!