### PR TITLE
Remove planned refactoring needed for the NANODBC_HANDLE_NODATA_BUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,5 @@ vagrant@vagrant-ubuntu-precise-64:~$ make nanodbc
 - Clean up `bind_*` family of functions, reduce any duplication.
 - Improve documentation: The main website and API docs should be more responsive.
 - Provide more examples in documentation, more details, and point out any gotchas.
-- Refactor code to remove the need for the `NANODBC_HANDLE_NODATA_BUG` option.
 - Versioned generated source level API documentation for `release` and `latest`. For each major and minor published versions too?
 - Add "HOWTO Build" documentation for Windows, OS X, and Linux.


### PR DESCRIPTION
There isn't an easy way to automatically handle buggy drivers.
See #33 for detailed discussion.