### PR TITLE
Add support for database-specific connection string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "DROP DATABASE IF EXISTS nanodbc_tests; CREATE DATABASE IF NOT EXISTS nanodbc_tests;" -uroot; fi
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost';" -uroot; fi
-  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then export NANODBC_TEST_CONNSTR="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then export NANODBC_TEST_CONNSTR_MYSQL="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
   - if [[ "$DB" == "postgresql" ]]; then sudo odbcinst -i -d -f /usr/share/psqlodbc/odbcinst.ini.template; fi
   - if [[ "$DB" == "postgresql" ]]; then psql -c "CREATE DATABASE nanodbc_tests;" -U postgres; fi
-  - if [[ "$DB" == "postgresql" ]]; then export NANODBC_TEST_CONNSTR="DRIVER={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc_tests;UID=postgres;"; fi
+  - if [[ "$DB" == "postgresql" ]]; then export NANODBC_TEST_CONNSTR_PGSQL="DRIVER={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc_tests;UID=postgres;"; fi
   - if [[ "$DB" == "sqlite" ]]; then sudo odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini; fi
   - odbcinst -j
   - if [[ -n "$DB" && -f "$ODBCSYSINI/odbcinst.ini" ]]; then odbcinst -q -d; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,13 +83,13 @@ build:
 test_script:
   - ps: |
       if ($env:DB -Match "MSSQL") {
-        $env:NANODBC_TEST_CONNSTR="Driver={ODBC Driver 11 for SQL Server};Server=(local)\SQL2014;Database=master;UID=sa;PWD=Password12!;"
+        $env:NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 11 for SQL Server};Server=(local)\SQL2014;Database=master;UID=sa;PWD=Password12!;"
         $test_name = "mssql_test"
       } elseif ($env:DB -Match "MySQL") {
-        $env:NANODBC_TEST_CONNSTR="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc_test;User=root;Password=Password12!;"
+        $env:NANODBC_TEST_CONNSTR_MYSQL="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc_test;User=root;Password=Password12!;"
         $test_name = "mysql_test"
       } elseif ($env:DB -Match "PostgreSQL") {
-        $env:NANODBC_TEST_CONNSTR="Driver={PostgreSQL ANSI(x64)};Server=127.0.0.1;Port=5432;Database=nanodbc_test;Uid=postgres;Pwd=Password12!;"
+        $env:NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI(x64)};Server=127.0.0.1;Port=5432;Database=nanodbc_test;Uid=postgres;Pwd=Password12!;"
         $test_name = "postgresql_test"
       } elseif ($env:DB -Match "SQLite") {
         $test_name = "sqlite_test"
@@ -97,7 +97,6 @@ test_script:
         throw 'TODO: ' + $env:DB + ' not configured yet'
       }
       Write-Host Running $Env:CONFIGURATION build test: $test_name -ForegroundColor Magenta
-      Write-Host NANODBC_TEST_CONNSTR=$env:NANODBC_TEST_CONNSTR -ForegroundColor Magenta
   - ps: |
       $cmd = 'ctest -V --output-on-failure -C ' + $Env:CONFIGURATION + ' -R ' + $test_name
       iex "& $cmd"

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -48,7 +48,7 @@ struct base_test_fixture
         > integral_test_types;
 
     base_test_fixture()
-    : connection_string_(get_connection_string_from_env())
+    : connection_string_(get_connection_string_from_env("NANODBC_TEST_CONNSTR"))
     {
     }
 
@@ -85,21 +85,20 @@ struct base_test_fixture
         return ss.str();
     }
 
-    nanodbc::string_type get_connection_string_from_env() const
+    nanodbc::string_type get_connection_string_from_env(const char* var) const
     {
-        const char* env_name = "NANODBC_TEST_CONNSTR";
         char* env_value = nullptr;
         std::string connection_string;
         #ifdef _MSC_VER
             std::size_t env_len(0);
-            errno_t err = _dupenv_s(&env_value, &env_len, env_name);
+            errno_t err = _dupenv_s(&env_value, &env_len, var);
             if(!err && env_value)
             {
                 connection_string = env_value;
                 std::free(env_value);
             }
         #else
-            env_value = std::getenv(env_name);
+            env_value = std::getenv(var);
             if(!env_value) return nanodbc::string_type();
             connection_string = env_value;
         #endif

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -12,6 +12,8 @@ namespace
         mssql_fixture()
         : base_test_fixture(/* connecting string from NANODBC_TEST_CONNSTR environment variable)*/)
         {
+            if (connection_string_.empty())
+                connection_string_ = get_connection_string_from_env("NANODBC_TEST_CONNSTR_MSSQL");
         }
 
         virtual ~mssql_fixture() NANODBC_NOEXCEPT

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -12,6 +12,8 @@ namespace
         mysql_fixture()
         : base_test_fixture(/* connecting string from NANODBC_TEST_CONNSTR environment variable)*/)
         {
+            if (connection_string_.empty())
+                connection_string_ = get_connection_string_from_env("NANODBC_TEST_CONNSTR_MYSQL");
         }
 
         virtual ~mysql_fixture() NANODBC_NOEXCEPT

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -12,6 +12,8 @@ namespace
         odbc_fixture()
         : base_test_fixture(/* connecting string from NANODBC_TEST_CONNSTR environment variable)*/)
         {
+            if (connection_string_.empty())
+                connection_string_ = get_connection_string_from_env("NANODBC_TEST_CONNSTR_ODBC");
         }
 
         virtual ~odbc_fixture() NANODBC_NOEXCEPT

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -12,6 +12,8 @@ namespace
         postgresql_fixture()
         : base_test_fixture(/* connecting string from NANODBC_TEST_CONNSTR environment variable)*/)
         {
+            if (connection_string_.empty())
+                connection_string_ = get_connection_string_from_env("NANODBC_TEST_CONNSTR_PGSQL");
         }
 
         virtual ~postgresql_fixture() NANODBC_NOEXCEPT


### PR DESCRIPTION
Tests for all databases first read `NANODBC_TEST_CONNSTR`, then try `NANODBC_TEST_CONNSTR_{ODBC|MSSQL|MYSQL|PGSQL}` equivalent.

This allows to configure and run all tests at once.