### PR TITLE
std::wstring_convert performance bottleneck

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -225,10 +225,10 @@ namespace
                 // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
                 // Why static? http://stackoverflow.com/questions/26196686/utf8-utf16-codecvt-poor-performance
                 auto p = reinterpret_cast<unsigned short const*>(in.data());
-                static std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short> converter;
+                static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short> converter;
                 out = converter.to_bytes(p, p + in.size());
             #else
-                static std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t> converter;
+                static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t> converter;
                 out = converter.to_bytes(in);
             #endif
         #endif


### PR DESCRIPTION
I recently updated a project from VS2010 to VS2015 (finally!) and nanodbc 1.x to 2.x. I saw a horrible slowdown that can be traced to the poor performance of the `std::wstring_convert` constructor; see [this post](http://stackoverflow.com/questions/26196686/utf8-utf16-codecvt-poor-performance) for discussion. Making this converter static seems to have addressed the problem.

I only made the change in the VS2015 version of the converter, but I suspect this same pattern should be considered anywhere `std::wstring_convert` is used.