### PR TITLE
Put the string lengths in their proper place

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2551,7 +2551,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     if(ValueLenOrInd > 0)
                         out.append(buffer, std::min<std::size_t>(ValueLenOrInd, col.ctype_ == SQL_C_BINARY ? buffer_size : buffer_size - 1));
                     else if(ValueLenOrInd == SQL_NULL_DATA)
-                        *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
+                        col.cbdata_[rowset_position_] = (SQLINTEGER) SQL_NULL_DATA;
                     // Sequence of successful calls is:
                     // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
                 } while(rc == SQL_SUCCESS_WITH_INFO);
@@ -2598,7 +2598,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     if(ValueLenOrInd > 0)
                         out.append(buffer, std::min<std::size_t>(ValueLenOrInd, buffer_size - 1));
                     else if(ValueLenOrInd == SQL_NULL_DATA)
-                        *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
+                        col.cbdata_[rowset_position_] = (SQLINTEGER) SQL_NULL_DATA;
                     // Sequence of successful calls is:
                     // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
                 } while(rc == SQL_SUCCESS_WITH_INFO);
@@ -2612,7 +2612,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
             {
                 // Type is unicode in the database, convert if necessary
                 const SQLWCHAR* s = reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
-                const string_type::size_type str_size = *col.cbdata_ / sizeof(SQLWCHAR);
+                const string_type::size_type str_size = col.cbdata_[rowset_position_] / sizeof(SQLWCHAR);
                 wide_string_type temp(s, s + str_size);
                 convert(temp, result);
             }
@@ -2786,7 +2786,7 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(short c
                         out.insert(std::end(out), buffer, buffer + buffer_size_filled);
                     }
                     else if(ValueLenOrInd == SQL_NULL_DATA)
-                        *col.cbdata_ = (SQLINTEGER) SQL_NULL_DATA;
+                        col.cbdata_[rowset_position_] = (SQLINTEGER) SQL_NULL_DATA;
                     // Sequence of successful calls is:
                     // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
                 } while(rc == SQL_SUCCESS_WITH_INFO);


### PR DESCRIPTION
Wow, I wonder how this one slipped through the cracks for so long!

The `cbdata_` vector is of length `rowset_size_`. For strings, it contains either the string length, or `SQL_NULL_DATA`. Obviously, the length of string `N` should be in `cbdata_[N]`. But for some reason, the code was expecting to see every string length in the zeroth position. This was causing me problems when reading data that had variable string lengths.