### PR TITLE
Verify setting separate value/indicator buffers for all SQLBindCol

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2645,21 +2645,21 @@ private:
         {
             bound_column& col = bound_columns_[i];
             col.cbdata_ = new null_type[rowset_size_];
-            if(col.blob_)
-            {
-                NANODBC_CALL_RC(
-                    SQLBindCol
-                    , rc
-                    , stmt_.native_statement_handle()
-                    , i + 1
-                    , col.ctype_
-                    , 0
-                    , 0
-                    , col.cbdata_);
-                if(!success(rc))
-                    NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
-            }
-            else
+            //if(col.blob_)
+            //{
+            //    NANODBC_CALL_RC(
+            //        SQLBindCol
+            //        , rc
+            //        , stmt_.native_statement_handle()
+            //        , i + 1
+            //        , col.ctype_
+            //        , 0
+            //        , 0
+            //        , col.cbdata_);
+            //    if(!success(rc))
+            //        NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
+            //}
+            //else
             {
                 col.pdata_ = new char[rowset_size_ * col.clen_];
                 NANODBC_CALL_RC(


### PR DESCRIPTION
This is an extension to #166:

* Also, set separate value/indicator buffers for all `SQLBindCol`, not only for non-BLOB data.
* This is an attmpt to *evaluate* if it is a correct fix for discovered issue with `SQLFetch` does not setting null indicator for nullable variable-length column.

So, we can compare how the new **null_access_test** behaves with and without the fix.