### PR TITLE
Fix some issues with the async support, plus add async prepare and next.

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -203,3 +203,30 @@ TEST_CASE_METHOD(mssql_fixture, "while_next_iteration_test", "[mssql][looping]")
 {
     while_next_iteration_test();
 }
+
+#ifdef WIN32
+TEST_CASE_METHOD(mssql_fixture, "async_test", "[mssql][async]")
+{
+    HANDLE event_handle = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+    nanodbc::connection conn;
+    if ( conn.async_connect(connection_string_, event_handle) )
+        WaitForSingleObject(event_handle, INFINITE);
+    conn.async_complete();
+
+    nanodbc::statement stmt(conn);
+    if ( stmt.async_prepare(NANODBC_TEXT("select count(*) from sys.tables;"), event_handle) )
+        WaitForSingleObject(event_handle, INFINITE);
+    stmt.complete_prepare();
+
+    if ( stmt.async_execute(event_handle) )
+        WaitForSingleObject(event_handle, INFINITE);
+    nanodbc::result row = stmt.complete_execute();
+
+    if ( row.async_next(event_handle) )
+        WaitForSingleObject(event_handle, INFINITE);
+    REQUIRE(row.complete_next());
+
+    REQUIRE(row.get<int>(0) >= 0);
+}
+#endif //WIN32


### PR DESCRIPTION
This PR continues the async work started in PRs #45 and #55.

It turns out drivers may opt to complete async operations immediately in certain situations, so the async_ functions now return a boolean indicating whether the operation has actually been run asynchronously (ie. whether the ODBC call returned SQL_STILL_EXECUTING). This allows the application code to avoid waiting in vain for events in these situations.

I've also added support for async prepare and async next. Since we now have support for multiple different async operations at statement level, I renamed the old statement::async_complete to statement::complete_execute, to match the new statement::complete_prepare. (Though I kept the old async_complete as an undocumented function to avoid breaking any existing code.)

The following example code demonstrates all the async features:
```
HANDLE event_handle = CreateEvent(NULL, FALSE, FALSE, NULL);

nanodbc::connection conn;
if ( conn.async_connect(some_connection_string, event_handle) )
    WaitForSingleObject(event_handle, INFINITE);
conn.async_complete();

nanodbc::statement stmt(conn);
if ( stmt.async_prepare(some_query_string, event_handle) )
    WaitForSingleObject(event_handle, INFINITE);
stmt.complete_prepare();

if ( stmt.async_execute(event_handle) )
    WaitForSingleObject(event_handle, INFINITE);
nanodbc::result row = stmt.complete_execute();

if ( row.async_next(event_handle) )
    WaitForSingleObject(event_handle, INFINITE);
row.complete_next();

// first row in result set ready for use
```