### PR TITLE
Add support for time column type

### DIFF
--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -286,6 +286,14 @@ struct date
     std::int16_t day; //!< Day of the month [1-31].
 };
 
+//! \brief A type for representing time data.
+struct time
+{
+  std::int16_t hour;   //!< Hours since midnight [0-23].
+  std::int16_t min;    //!< Minutes after the hour [0-59].
+  std::int16_t sec;    //!< Seconds after the minute.
+};
+
 //! \brief A type for representing timestamp data.
 struct timestamp
 {


### PR DESCRIPTION
This adds the ability to read `SQL_TIME`/`SQL_TYPE_TIME` columns as a structured datatype by creating a `time` struct with hour, minute, and second fields.

I followed the [structure of `TIME_STRUCT`](https://msdn.microsoft.com/en-us/library/ms714556(v=vs.85).aspx) to create the `nanodbc::time` struct to match `date` and `timestamp`.  