### PR TITLE
Add test for integer to string conversion (SQLite only)

### DIFF
--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -158,6 +158,42 @@ TEST_CASE_METHOD(sqlite_fixture, "integral_test", "[sqlite][integral]")
     integral_test<sqlite_fixture>();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "integral_to_string_conversion_test", "[sqlite][integral]")
+{
+    // TODO: Move to common tests
+    nanodbc::connection connection = connect();
+    create_table(connection, NANODBC_TEXT("integral_to_string_conversion_test"), NANODBC_TEXT("(i int, n int)"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (1, 0);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (2, 255);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (3, -128);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (4, 127);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (5, -32768);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (6, 32767);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (7, -2147483648);"));
+    execute(connection, NANODBC_TEXT("insert into integral_to_string_conversion_test values (8, 2147483647);"));
+    auto results = execute(connection, NANODBC_TEXT("select * from integral_to_string_conversion_test order by i asc;"));
+
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("0"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("255"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-128"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("127"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-32768"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("32767"));
+    REQUIRE(results.next());
+    // FIXME: SQLite ODBC driver reports column size of 10 leading to truncation
+    // "-214748364" == "-2147483648"
+    // The driver bug?
+    //REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-2147483648"));
+    REQUIRE(results.next());
+    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("2147483647"));
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "move_test", "[sqlite][move]")
 {
     move_test();


### PR DESCRIPTION
The test should cover fix submitted in #176.

------

Note, the CI builds are likely to fail, because the test requires #176 fix.
Without it, garbage is written to result buffers:
```
nanodbc\test\sqlite_test.cpp(180): FAILED:
  REQUIRE( results.get<nanodbc::string_type>(1) == L"-128" )
with expansion:
  "65408" == "-128"
```