### PR TITLE
Add nanodbc::list_drivers free function

### DIFF
--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -77,6 +77,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <list>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -1465,6 +1466,18 @@ private:
 
 //! @}
 
+struct driver
+{
+    struct attribute
+    {
+        nanodbc::string_type keyword;
+        nanodbc::string_type value;
+    };
+
+    nanodbc::string_type name;
+    std::list<attribute> attributes;
+};
+
 // 8888888888                            8888888888                         888    d8b
 // 888                                   888                                888    Y8P
 // 888                                   888                                888
@@ -1479,6 +1492,8 @@ private:
 //! \brief Convenience functions.
 //!
 //! @{
+
+std::list<driver> list_drivers();
 
 //! \brief Immediately opens, prepares, and executes the given query directly on the given connection.
 //! \param conn The connection where the statement will be executed.

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -21,6 +21,11 @@ struct mssql_fixture : public base_test_fixture
 };
 }
 
+TEST_CASE_METHOD(mssql_fixture, "driver_test", "[mssql][driver]")
+{
+    driver_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "affected_rows_test", "[mssql][affected_rows]")
 {
     // Skip on SQL Server 2008, see details at

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -23,6 +23,11 @@ namespace
 
 // FIXME: No catlog_* tests for MySQL. Not supported?
 
+TEST_CASE_METHOD(mysql_fixture, "driver_test", "[mysql][driver]")
+{
+    driver_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "affected_rows_test", "[mysql][affected_rows]")
 {
     nanodbc::connection conn = connect();

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -21,6 +21,11 @@ namespace
     };
 }
 
+TEST_CASE_METHOD(odbc_fixture, "driver_test", "[odbc][driver]")
+{
+    driver_test();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "blob_test", "[odbc][blob]")
 {
     blob_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -23,6 +23,11 @@ namespace
 
 // TODO: add blob (bytea) test
 
+TEST_CASE_METHOD(postgresql_fixture, "driver_test", "[postgresql][driver]")
+{
+    driver_test();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "catalog_columns_test", "[postgresql][catalog][columns]")
 {
     catalog_columns_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -95,6 +95,11 @@ TEST_CASE_METHOD(sqlite_fixture, "affected_rows_test", "[sqlite][affected_rows]"
 }
 #endif
 
+TEST_CASE_METHOD(sqlite_fixture, "driver_test", "[sqlite][driver]")
+{
+    driver_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "blob_test", "[sqlite][blob]")
 {
     blob_test();


### PR DESCRIPTION
Convenient wrapper for ODBC API call `SQLDrivers`.

Add two utility functions to base_test_fixture: `connection_string_parameter` and `iequals_string`,
which are used in `list_drivers` test exercising the new wrapper.

------

Note, if we decide to publish other string utilities like `convert`, that actually could be convenient for nanodbc users, then we may want to publish `iequals_string` as `nanodbc::iequals` as well.