### PR TITLE
Add two catalog operations: list_catalogs and list_schemas

### DIFF
--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1309,10 +1309,16 @@ inline auto end(result& /*r*/) { return result_iterator(); }
 //                                                  "Y88P"
 // MARK: Catalog -
 
+//! \brief A resource for get catalog information from connected data source.
+//!
+//! Queries are performed using the Catalog Functions in ODBC.
+//! All provided operations are convenient wrappers around the ODBC API
+//! The original ODBC behaviour should not be affected by any added processing.
 class catalog
 {
 public:
 
+    //! \brief Result set for a list of tables in the data source.
     class tables
     {
     public:
@@ -1329,6 +1335,7 @@ public:
         result result_;
     };
 
+    //! \brief Result set for a list of columns in one or more tables.
     class columns
     {
     public:
@@ -1399,6 +1406,7 @@ public:
         result result_;
     };
 
+    //! \brief Result set for a list of columns that compose the primary key of a single table.
     class primary_keys
     {
     public:
@@ -1426,11 +1434,10 @@ public:
     //! \brief Creates catalog operating on database accessible through the specified connection.
     catalog(connection& conn);
 
-    //! \brief Creates result set with tables information.
-    //!
-    //! Tables information is obtained by executing SQLTable function within
+    //! \brief Creates result set with catalogs, schemas, tables, or table types.
+    //! Tables information is obtained by executing `SQLTable` function within
     //! scope of the connected database accessible with the specified connection.
-    //! Since this function is implemented in terms of the SQLTables, it returns
+    //! Since this function is implemented in terms of the `SQLTable`s, it returns
     //! result set ordered by TABLE_TYPE, TABLE_CAT, TABLE_SCHEM, and TABLE_NAME.
     //!
     //! All arguments are treated as the Pattern Value Arguments.
@@ -1441,11 +1448,11 @@ public:
       , const string_type& schema = string_type()
       , const string_type& catalog = string_type());
 
-    //! \brief Creates result set with columns information in specified tables.
+    //! \brief Creates result set with columns in one or more tables.
     //!
-    //! Columns information is obtained by executing SQLColumns function within
+    //! Columns information is obtained by executing `SQLColumns` function within
     //! scope of the connected database accessible with the specified connection.
-    //! Since this function is implemented in terms of the SQLColumns, it returns
+    //! Since this function is implemented in terms of the `SQLColumns`, it returns
     //! result set ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, and ORDINAL_POSITION.
     //!
     //! All arguments are treated as the Pattern Value Arguments.
@@ -1456,10 +1463,10 @@ public:
       , const string_type& schema = string_type()
       , const string_type& catalog = string_type());
 
-    //! \brief Creates result set with primary key information.
+    //! \brief Creates result set with columns that compose the primary key of a single table.
     //!
     //! Returns result set with column names that make up the primary key for a table.
-    //! The primary key information is obtained by executing SQLPrimaryKey function within
+    //! The primary key information is obtained by executing `SQLPrimaryKey` function within
     //! scope of the connected database accessible with the specified connection.
     //!
     //! All arguments are treated as the Pattern Value Arguments.
@@ -1468,6 +1475,16 @@ public:
         const string_type& table
       , const string_type& schema = string_type()
       , const string_type& catalog = string_type());
+
+    //! \brief Returns names of all catalogs (or databases) available in connected data source.
+    //!
+    //! Executes `SQLTable` function with `SQL_ALL_CATALOG` as catalog search pattern.
+    std::list<string_type> list_catalogs();
+
+    //! \brief Returns names of all schemas available in connected data source.
+    //!
+    //! Executes `SQLTable` function with `SQL_ALL_SCHEMAS` as schema search pattern.
+    std::list<string_type> list_schemas();
 
 private:
     connection conn_;

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -276,6 +276,26 @@ struct base_test_fixture
         REQUIRE(results.get<nanodbc::string_type>(0) == s);
     }
 
+    void catalog_list_catalogs_test()
+    {
+        nanodbc::connection connection = connect();
+        REQUIRE(connection.connected());
+        nanodbc::catalog catalog(connection);
+
+        auto names = catalog.list_catalogs();
+        REQUIRE(!names.empty());
+    }
+
+    void catalog_list_schemas_test()
+    {
+        nanodbc::connection connection = connect();
+        REQUIRE(connection.connected());
+        nanodbc::catalog catalog(connection);
+
+        auto names = catalog.list_schemas();
+        REQUIRE(!names.empty());
+    }
+
     void catalog_columns_test()
     {
         nanodbc::connection connection = connect();

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -177,6 +177,16 @@ TEST_CASE_METHOD(mssql_fixture, "block_cursor_with_nvarchar_and_second_row_null_
     REQUIRE(!results.next());
 }
 
+TEST_CASE_METHOD(mssql_fixture, "catalog_list_catalogs_test", "[mssql][catalog][catalogs]")
+{
+    catalog_list_catalogs_test();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "catalog_list_schemas_test", "[mssql][catalog][catalogs]")
+{
+    catalog_list_schemas_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "catalog_columns_test", "[mssql][catalog][columns]")
 {
     catalog_columns_test();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -75,6 +75,16 @@ TEST_CASE_METHOD(mysql_fixture, "blob_test", "[mysql][blob]")
     blob_test();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "catalog_list_catalogs_test", "[mysql][catalog][catalogs]")
+{
+    catalog_list_catalogs_test();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "catalog_list_schemas_test", "[mysql][catalog][catalogs]")
+{
+    catalog_list_schemas_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "catalog_columns_test", "[mysql][catalog][columns]")
 {
     catalog_columns_test();


### PR DESCRIPTION
Both functions query data source using ODBC API call SQLTable:
* `list_catalogs` with `SQL_ALL_CATALOGS to get list of valid catalogs.
* `list_schemas` with `SQL_ALL_SCHEMAS` to get list of valid schemas.

------
Important detail to note is that the current `nanodbc::catalog` look-up functions have not been tested 
in the [Identifier Arguments](https://msdn.microsoft.com/en-us/library/ms714579.aspx) mode, so it is (implicitly) assumed the connection/statement attribute `SQL_ATTR_METADATA_ID` is `SQL_FALSE`.

------
There is number of quirks related to use of `SQLTables`, so it is worth to have a look at these pages to get better understanding:
* [Arguments in Catalog Functions](https://msdn.microsoft.com/en-us/library/ms716447.aspx)
* [SQLTables - MariaDB Knowledge Base](https://mariadb.com/kb/en/sql-99/sqltables/)