### PR TITLE
WIP: Converter templates for more efficient processing

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -213,54 +213,76 @@ namespace
         return i;
     }
 
-    inline void convert(const wide_string_type& in, std::string& out)
-    {
-        #ifdef NANODBC_USE_BOOST_CONVERT
-            using boost::locale::conv::utf_to_utf;
-            out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
-        #else
-            #if defined(_MSC_VER) && (_MSC_VER == 1900)
-                // Workaround for confirmed bug in VS2015. See:
-                // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
-                // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
-                auto p = reinterpret_cast<unsigned short const*>(in.data());
-                out = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().to_bytes(p, p + in.size());
-            #else
-                out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().to_bytes(in);
-            #endif
-        #endif
-    }
+	template <class T>
+	inline void convert(const T* beg, size_t n, std::basic_string<T>& out)
+	{
+		out.assign(beg, n);
+	}
 
-    #ifdef NANODBC_USE_UNICODE
-        inline void convert(const std::string& in, wide_string_type& out)
-        {
-            #ifdef NANODBC_USE_BOOST_CONVERT
-                using boost::locale::conv::utf_to_utf;
-                out = utf_to_utf<wide_char_t>(in.c_str(), in.c_str() + in.size());
-            #elif defined(_MSC_VER) && (_MSC_VER == 1900)
-                // Workaround for confirmed bug in VS2015. See:
-                // https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
-                // https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
-                auto s = std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short>().from_bytes(in);
-                auto p = reinterpret_cast<wide_char_t const*>(s.data());
-                out.assign(p, p + s.size());
-            #else
-                out = std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t>().from_bytes(in);
-            #endif
-        }
+	inline void convert(const wide_char_t* beg, size_t n, std::string& out)
+	{
+#ifdef NANODBC_USE_BOOST_CONVERT
+		using boost::locale::conv::utf_to_utf;
+		out = utf_to_utf<char>(beg, beg + n);
+#elif defined(_MSC_VER) && (_MSC_VER == 1900)
+		// Workaround for confirmed bug in VS2015. See:
+		// https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
+		// https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+		// Why static? http://stackoverflow.com/questions/26196686/utf8-utf16-codecvt-poor-performance
+		static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short> converter;
+		out = converter.to_bytes(reinterpret_cast<unsigned short const*>(beg),
+			                     reinterpret_cast<unsigned short const*>(beg + n));
+#else
+		static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t> converter;
+		out = converter.to_bytes(beg, beg + n);
+#endif
+	}
 
-        inline void convert(const wide_string_type& in, wide_string_type& out)
-        {
-            out = in;
-        }
-    #else
-        inline void convert(const std::string& in, std::string& out)
-        {
-            out = in;
-        }
-    #endif
+	inline void convert(const char* beg, size_t n, wide_string_type& out)
+	{
+#ifdef NANODBC_USE_BOOST_CONVERT
+		using boost::locale::conv::utf_to_utf;
+		out = utf_to_utf<wide_char_t>(beg, beg + n);
+#elif defined(_MSC_VER) && (_MSC_VER == 1900)
+		// Workaround for confirmed bug in VS2015. See:
+		// https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
+		// https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+		// Why static? http://stackoverflow.com/questions/26196686/utf8-utf16-codecvt-poor-performance
+		static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<unsigned short>, unsigned short> converter;
+		auto s = converter.from_bytes(beg, beg + n);
+		auto p = reinterpret_cast<wide_char_t const*>(s.data());
+		out.assign(p, p + s.size());
+#else
+		static thread_local std::wstring_convert<NANODBC_CODECVT_TYPE<wide_char_t>, wide_char_t> converter;
+		out = converter.from_bytes(beg, beg + n);
+#endif
+	}
 
-    // Attempts to get the most recent ODBC error as a string.
+	template <class T>
+	inline void convert(const char* beg, std::basic_string<T>& out)
+	{
+		convert(beg, std::strlen(beg), out);
+	}
+
+	template <class T>
+	inline void convert(const wchar_t* beg, std::basic_string<T>& out)
+	{
+		convert(beg, std::wcslen(beg), out);
+	}
+
+	template <class T>
+	inline void convert(std::basic_string<T>&& in, std::basic_string<T>& out)
+	{
+		out.assign(in);
+	}
+
+	template <class T, class U>
+	inline void convert(const std::basic_string<T>& in, std::basic_string<U>& out)
+	{
+		convert(in.data(), in.size(), out);
+	}
+
+	// Attempts to get the most recent ODBC error as a string.
     // Always returns std::string, even in unicode mode.
     inline std::string recent_error(
         SQLHANDLE handle
@@ -313,7 +335,7 @@ namespace
 
             if(!success(rc))
             {
-                convert(result, rvalue);
+                convert(std::move(result), rvalue);
                 return rvalue;
             }
 
@@ -331,7 +353,7 @@ namespace
             #endif
         } while(rc != SQL_NO_DATA);
 
-        convert(result, rvalue);
+        convert(std::move(result), rvalue);
         state = std::string(&sql_state[0], &sql_state[arrlen(sql_state) - 1]);
         native = native_error;
         std::string status = state;
@@ -1999,23 +2021,13 @@ void statement::statement_impl::bind_strings(
 
     if(null_sentry)
     {
-        for(std::size_t i = 0; i < elements; ++i)
+		std::string narrow_lhs, narrow_rhs;
+		convert(string_type(null_sentry), narrow_rhs); 
+		for(std::size_t i = 0; i < elements; ++i)
         {
-            const string_type s_lhs(values + i * length, values + (i + 1) * length);
-            const string_type s_rhs(null_sentry);
-            #if NANODBC_USE_UNICODE
-                std::string narrow_lhs;
-                narrow_lhs.reserve(s_lhs.size());
-                convert(s_lhs, narrow_lhs);
-                std::string narrow_rhs;
-                narrow_rhs.reserve(s_rhs.size());
-                convert(s_rhs, narrow_lhs);
-                if(std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length))
-                    bind_len_or_null_[param][i] = parameter_size;
-            #else
-                if(std::strncmp(s_lhs.c_str(), s_rhs.c_str(), length))
-                    bind_len_or_null_[param][i] = parameter_size;
-            #endif
+            convert(values + i * length, length, narrow_lhs);
+            if(std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length))
+                bind_len_or_null_[param][i] = parameter_size;
         }
     }
     else if(nulls)
@@ -2795,7 +2807,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
                 } while(rc == SQL_SUCCESS_WITH_INFO);
                 if(rc == SQL_SUCCESS || rc == SQL_NO_DATA)
-                    convert(out, result);
+                    convert(std::move(out), result);
                 else
                     if(!success(rc))
                         NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);
@@ -2803,8 +2815,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
             else
             {
                 const char* s = col.pdata_ + rowset_position_ * col.clen_;
-                const std::string::size_type str_size = std::strlen(s);
-                result.assign(s, s + str_size);
+				convert(s, result);
             }
             return;
         }
@@ -2847,7 +2858,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                     // SQL_NO_DATA or SQL_SUCCESS_WITH_INFO followed by SQL_SUCCESS.
                 } while(rc == SQL_SUCCESS_WITH_INFO);
                 if(rc == SQL_SUCCESS || rc == SQL_NO_DATA)
-                    convert(out, result);
+                    convert(std::move(out), result);
                 else
                     if(!success(rc))
                         NANODBC_THROW_DATABASE_ERROR(stmt_.native_statement_handle(), SQL_HANDLE_STMT);;
@@ -2857,8 +2868,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                 // Type is unicode in the database, convert if necessary
                 const SQLWCHAR* s = reinterpret_cast<SQLWCHAR*>(col.pdata_ + rowset_position_ * col.clen_);
                 const string_type::size_type str_size = col.cbdata_[rowset_position_] / sizeof(SQLWCHAR);
-                wide_string_type temp(s, s + str_size);
-                convert(temp, result);
+				convert(s, str_size, result);
             }
             return;
         }
@@ -2872,70 +2882,45 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 
         case SQL_C_LONG:
         {
-            std::string buffer;
-            buffer.reserve(column_size + 1); // ensure terminating null
-            buffer.resize(buffer.capacity());
-            using std::fill;
-            fill(buffer.begin(), buffer.end(), '\0');
-            const int32_t data = *reinterpret_cast<int32_t*>(col.pdata_ + rowset_position_ * col.clen_);
+            std::string buffer(column_size + 1, 0); // ensure terminating null
+            const wide_char_t data = *reinterpret_cast<wide_char_t*>(col.pdata_ + rowset_position_ * col.clen_);
             const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%d", data);
             if(bytes == -1)
                 throw type_incompatible_error();
-            else if((SQLULEN)bytes < column_size)
-                buffer.resize(bytes);
-            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
-            result.reserve(buffer.size() * sizeof(string_type::value_type));
-            convert(buffer, result);
+			// Passing the C pointer drops trailing nulls
+            convert(buffer.data(), result);
             return;
         }
 
         case SQL_C_SBIGINT:
         {
             using namespace std; // in case intmax_t is in namespace std
-            std::string buffer;
-            buffer.reserve(column_size + 1); // ensure terminating null
-            buffer.resize(buffer.capacity());
-            using std::fill;
-            fill(buffer.begin(), buffer.end(), '\0');
-            const intmax_t data = (intmax_t)*reinterpret_cast<int64_t*>(col.pdata_ + rowset_position_ * col.clen_);
+			std::string buffer(column_size + 1, 0); // ensure terminating null
+			const intmax_t data = (intmax_t)*reinterpret_cast<int64_t*>(col.pdata_ + rowset_position_ * col.clen_);
             const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%jd", data);
             if(bytes == -1)
                 throw type_incompatible_error();
-            else if((SQLULEN)bytes < column_size)
-                buffer.resize(bytes);
-            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
-            result.reserve(buffer.size() * sizeof(string_type::value_type));
-            convert(buffer, result);
+			// Passing the C pointer drops trailing nulls
+			convert(buffer.data(), result);
             return;
         }
 
         case SQL_C_FLOAT:
         {
-            std::string buffer;
-            buffer.reserve(column_size + 1); // ensure terminating null
-            buffer.resize(buffer.capacity());
-            using std::fill;
-            fill(buffer.begin(), buffer.end(), '\0');
+			std::string buffer(column_size + 1, 0); // ensure terminating null
             const float data = *reinterpret_cast<float*>(col.pdata_ + rowset_position_ * col.clen_);
             const int bytes = std::snprintf(const_cast<char*>(buffer.data()), column_size + 1, "%f", data);
             if(bytes == -1)
                 throw type_incompatible_error();
-            else if((SQLULEN)bytes < column_size)
-                buffer.resize(bytes);
-            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
-            result.reserve(buffer.size() * sizeof(string_type::value_type));
-            convert(buffer, result);
+			// Passing the C pointer drops trailing nulls
+			convert(buffer.data(), result);
             return;
         }
 
         case SQL_C_DOUBLE:
         {
-            std::string buffer;
-            const SQLULEN width = column_size + 2; // account for decimal mark and sign
-            buffer.reserve(width + 1); // ensure terminating null
-            buffer.resize(buffer.capacity());
-            using std::fill;
-            fill(buffer.begin(), buffer.end(), '\0');
+			const SQLULEN width = column_size + 2; // account for decimal mark and sign
+			std::string buffer(width + 1, 0); // ensure terminating null
             const double data = *reinterpret_cast<double*>(col.pdata_ + rowset_position_ * col.clen_);
             const int bytes = std::snprintf(
                 const_cast<char*>(buffer.data())
@@ -2945,11 +2930,8 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
                 , data);
             if(bytes == -1)
                 throw type_incompatible_error();
-            else if((SQLULEN)bytes < column_size)
-                buffer.resize(bytes);
-            buffer.resize(std::strlen(buffer.data())); // drop any trailing nulls
-            result.reserve(buffer.size() * sizeof(string_type::value_type));
-            convert(buffer, result);
+			// Passing the C pointer drops trailing nulls
+            convert(buffer.data(), result);
             return;
         }
 


### PR DESCRIPTION
I'm really digging Visual 2015's profiler, which has made it easier for me to see the performance bottlenecks in my code. Even after my latest converter PR, one of the performance bottlenecks remained in the converter code. What is interesting is that this bottleneck didn't go away even when I adjusted my code so that no conversion is necessary. Another bottleneck turned out to be a large  number of unnecessary allocations as well, particularly when going between C-style and C++-style strings.

The set of `convert` functions provided here attempt to address this problem. Using template specialization we can use move semantics when that is appropriate, straight copying when conversion is unnecessary, and full conversion only when that is warranted. Because the decisions are made at compile time this should be a net win.

The result is not only a performance improvement in my specific case, but what I believe to be simpler code in many places throughout.

I've marked this WIP simply because I haven't yet investigated the interaction with existing tests
