### PR TITLE
Add new method result::column_decimal_digits

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2285,6 +2285,15 @@ public:
         return is_null(column);
     }
 
+    short column(const string_type& column_name) const
+    {
+        typedef std::map<string_type, bound_column*>::const_iterator iter;
+        iter i = bound_columns_by_name_.find(column_name);
+        if(i == bound_columns_by_name_.end())
+            throw index_range_error();
+        return i->second->column_;
+    }
+
     string_type column_name(short column) const
     {
         if(column >= bound_columns_size_)
@@ -2301,13 +2310,25 @@ public:
         return static_cast<long>(col.sqlsize_);
     }
 
-    short column(const string_type& column_name) const
+    int column_size(const string_type& column_name) const
     {
-        typedef std::map<string_type, bound_column*>::const_iterator iter;
-        iter i = bound_columns_by_name_.find(column_name);
-        if(i == bound_columns_by_name_.end())
+        const short column = this->column(column_name);
+        return column_size(column);
+    }
+
+    int column_decimal_digits(short column) const
+    {
+        if(column >= bound_columns_size_)
             throw index_range_error();
-        return i->second->column_;
+        bound_column& col = bound_columns_[column];
+        return col.scale_;
+    }
+
+    int column_decimal_digits(const string_type& column_name) const
+    {
+        const short column = this->column(column_name);
+        bound_column& col = bound_columns_[column];
+        return col.scale_;
     }
 
     int column_datatype(short column) const
@@ -4307,6 +4328,11 @@ bool result::is_null(const string_type& column_name) const
     return impl_->is_null(column_name);
 }
 
+short result::column(const string_type& column_name) const
+{
+    return impl_->column(column_name);
+}
+
 string_type result::column_name(short column) const
 {
     return impl_->column_name(column);
@@ -4317,9 +4343,19 @@ long result::column_size(short column) const
     return impl_->column_size(column);
 }
 
-short result::column(const string_type& column_name) const
+long result::column_size(const string_type& column_name) const
 {
-    return impl_->column(column_name);
+    return impl_->column_size(column_name);
+}
+
+int result::column_decimal_digits(short column) const
+{
+    return impl_->column_decimal_digits(column);
+}
+
+int result::column_decimal_digits(const string_type& column_name) const
+{
+    return impl_->column_decimal_digits(column_name);
 }
 
 int result::column_datatype(short column) const

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1187,6 +1187,13 @@ public:
     //! \throws database_error, index_range_error
     bool is_null(const string_type& column_name) const;
 
+    //! \brief Returns the column number of the specified column name.
+    //!
+    //! Columns are numbered from left to right and 0-indexed.
+    //! \param column_name column's name.
+    //! \throws index_range_error
+    short column(const string_type& column_name) const;
+
     //! \brief Returns the name of the specified column.
     //!
     //! Columns are numbered from left to right and 0-indexed.
@@ -1201,12 +1208,21 @@ public:
     //! \throws index_range_error
     long column_size(short column) const;
 
-    //! \brief Returns the column number of the specified column name.
+    //! \brief Returns the size of the specified column by name.
+    long column_size(const string_type& column_name) const;
+
+    //! \brief Returns the number of decimal digits of the specified column.
+    //!
+    //! Applies to exact numeric types (scale), datetime and interval types (prcision).
+    //! If the number cannot be determined or is not applicable, drivers typically return 0.
     //!
     //! Columns are numbered from left to right and 0-indexed.
-    //! \param column_name column's name.
+    //! \param column position.
     //! \throws index_range_error
-    short column(const string_type& column_name) const;
+    int column_decimal_digits(short column) const;
+
+    //! \brief Returns the number of decimal digits of the specified column by name.
+    int column_decimal_digits(const string_type& column_name) const;
 
     //! Returns a identifying integer value representing the SQL type of this column.
     int column_datatype(short column) const;

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -202,6 +202,11 @@ TEST_CASE_METHOD(mssql_fixture, "catalog_tables_test", "[mssql][catalog][tables]
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "column_descriptor_test", "[mssql][columns]")
+{
+    column_descriptor_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "dbms_info_test", "[mssql][dmbs][metadata][info]")
 {
     dbms_info_test();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -100,6 +100,11 @@ TEST_CASE_METHOD(mysql_fixture, "catalog_tables_test", "[mysql][catalog][tables]
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "column_descriptor_test", "[mysql][columns]")
+{
+    column_descriptor_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "dbms_info_test", "[mysql][dmbs][metadata][info]")
 {
     dbms_info_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -53,6 +53,11 @@ TEST_CASE_METHOD(postgresql_fixture, "catalog_tables_test", "[postgresql][catalo
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "column_descriptor_test", "[postgresql][columns]")
+{
+    column_descriptor_test();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "dbms_info_test", "[postgresql][dmbs][metadata][info]")
 {
     dbms_info_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -158,6 +158,11 @@ TEST_CASE_METHOD(sqlite_fixture, "catalog_tables_test", "[sqlite][catalog][table
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "column_descriptor_test", "[sqlite][columns]")
+{
+    column_descriptor_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "date_test", "[sqlite][date]")
 {
     date_test();
@@ -226,7 +231,7 @@ TEST_CASE_METHOD(sqlite_fixture, "integral_boundary_test", "[sqlite][integral]")
     nanodbc::connection connection = connect();
     drop_table(connection, NANODBC_TEXT("integral_boundary_test"));
 
-    // SQLite3 uses single storage class INTEGER for all integral SQL types 
+    // SQLite3 uses single storage class INTEGER for all integral SQL types
     execute(connection, NANODBC_TEXT("create table integral_boundary_test(i1 integer,i2 integer,i4 integer,i8 integer);"));
 
     auto const sql = NANODBC_TEXT("insert into integral_boundary_test(i1,i2,i4,i8) values (?,?,?,?);");


### PR DESCRIPTION
Add new method result::column_decimal_digits.
Add test for properties of result column descriptor.
Add missing overloads to access column properties by column name.
Re-arrange order of result and result_impl methods.

------
Question regarding the `result::column*` methods:
Some of them are overloaded for both, name and index, (e.g. `column_datatype`) while some are not (e.g. `column_size`). Do we want to unify the interface, provide overloaded variants for all or remove the overloads for name?
