### PR TITLE
Add catalog::find_table_privileges function

### DIFF
--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -282,6 +282,11 @@ TEST_CASE_METHOD(mssql_fixture, "catalog_tables_test", "[mssql][catalog][tables]
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "catalog_table_privileges_test", "[mssql][catalog][tables]")
+{
+    catalog_table_privileges_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "column_descriptor_test", "[mssql][columns]")
 {
     column_descriptor_test();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -99,6 +99,8 @@ TEST_CASE_METHOD(mysql_fixture, "catalog_tables_test", "[mysql][catalog][tables]
     catalog_tables_test();
 }
 
+// TODO: Add catalog_table_privileges_test - SQLTablePrivileges returns empty result set
+
 TEST_CASE_METHOD(mysql_fixture, "column_descriptor_test", "[mysql][columns]")
 {
     column_descriptor_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -58,6 +58,14 @@ TEST_CASE_METHOD(postgresql_fixture, "catalog_tables_test", "[postgresql][catalo
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(
+    postgresql_fixture,
+    "catalog_table_privileges_test",
+    "[postgresql][catalog][tables]")
+{
+    catalog_table_privileges_test();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "column_descriptor_test", "[postgresql][columns]")
 {
     column_descriptor_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -153,6 +153,12 @@ TEST_CASE_METHOD(sqlite_fixture, "catalog_tables_test", "[sqlite][catalog][table
     catalog_tables_test();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "catalog_table_privileges_test", "[sqlite][catalog][tables]")
+{
+    before_catalog_test();
+    catalog_table_privileges_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "column_descriptor_test", "[sqlite][columns]")
 {
     column_descriptor_test();


### PR DESCRIPTION
Add `catalog::table_privileges` result set

It is convenient wrapper for ODBC API call `SQLTablePrivileges` and its result set.