### PR TITLE
Adds a philosophy section to README.md.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,7 +198,7 @@ case of iODBC with unicode build enabled, `char32_t`. Boost.Test dropped in this
 - Cleans up style; removes CPP11 macros and C++03 support cruft.
 - Silence warnings and untabify.
 - Works with Unicode (std::wstring as nanodbc::string_type)
-- Using Nanodbc with SQL Server Native Client works with nvarchar(max) and varchar(max) fields in Win32 and Win64.
+- Using nanodbc with SQL Server Native Client works with nvarchar(max) and varchar(max) fields in Win32 and Win64.
 
 # v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 A small C++ wrapper for the native C ODBC API. Please see the [online documentation](http://lexicalunit.github.com/nanodbc/) for user information, example usage, propaganda, and detailed source level documentation.
 
+## Philosophy
+
+The native C API for working with ODBC is exorbitantly verbose, ridiculously complicated, and fantastically brittle. nanodbc addresses these frustrations! The goal for nanodbc is to make developers happy. Common tasks should be easy, requiring concise and simple code.
+
+The [latest C++ standards](https://isocpp.org/std/status) and [best practices](https://github.com/isocpp/CppCoreGuidelines) are _enthusiastically_ incorporated to make the library as future-proof as possible. To accommodate users who can not use the latest and greatest, [semantic versioning](http://semver.org/) and release notes will clarify required C++ features and/or standards for particular versions.
+
+### Design Decisions
+
+All complex objects in nanodbc follow the [pimpl (Pointer to IMPLementation)](http://c2.com/cgi/wiki?PimplIdiom) idiom to provide separation between interface and implementation, value semantics, and a clean `nanodbc.h` header file that includes nothing but standard C++ headers.
+
+nanodbc wraps ODBC code, providing a simpler way to do the same thing. We try to be as featureful as possible, but I can't guarantee you'll never have to write supporting ODBC code. Personally, I have never had to do so.
+
+Major features beyond what's already supported by ODBC are not within the scope of nanodbc. This is where the *nano* part of nanodbc becomes relevant: This library is _as minimal as possible_. That means no dependencies beyond standard C++ and typical ODBC headers. No features unsupported by existing ODBC API calls.
+
 ## Branches
 
 | Version | Description |

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1242,7 +1242,7 @@ public:
     ///
     /// There is a bug/limitation in ODBC drivers for SQL Server (and possibly others)
     /// which causes SQLBindCol() to never write SQL_NOT_NULL to the length/indicator
-    /// buffer unless you also bind the data column. Nanodbc's is_null() will return
+    /// buffer unless you also bind the data column. nanodbc's is_null() will return
     /// correct values for (n)varchar(max) columns when you ensure that SQLGetData()
     /// has been called for that column (i.e. after get() or get_ref() is called).
     ///


### PR DESCRIPTION
I was at [Abstractions.io Conference](http://abstractions.io/) in Pittsburgh this past weekend and I saw a talk by Nadia Odunayo about Code Hospitality. Here's a version of the talk presented at railsconf: https://www.youtube.com/watch?v=hHzWG1FltaE

I thought one of the suggestions she had could be an easy win for nanodbc: Add a Philosophy section to your project readme.