### PR TITLE
Fixed retrieving long strings from MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ before_script:
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then sudo odbcinst -i -d -f /usr/share/libmyodbc/odbcinst.ini; fi
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "DROP DATABASE IF EXISTS nanodbc_tests; CREATE DATABASE IF NOT EXISTS nanodbc_tests;" -uroot; fi
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost';" -uroot; fi
-  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then export NANODBC_TEST_CONNSTR_MYSQL="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;"; fi
+  - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then export NANODBC_TEST_CONNSTR_MYSQL="Driver=MySQL;Server=localhost;Database=nanodbc_tests;User=root;Password=;Option=3;big_packets=1;"; fi
   - if [[ "$DB" == "postgresql" ]]; then sudo odbcinst -i -d -f /usr/share/psqlodbc/odbcinst.ini.template; fi
   - if [[ "$DB" == "postgresql" ]]; then psql -c "CREATE DATABASE nanodbc_tests;" -U postgres; fi
   - if [[ "$DB" == "postgresql" ]]; then export NANODBC_TEST_CONNSTR_PGSQL="DRIVER={PostgreSQL ANSI};Server=localhost;Port=5432;Database=nanodbc_tests;UID=postgres;"; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,7 +135,7 @@ test_script:
         $env:NANODBC_TEST_CONNSTR_MSSQL="Driver={ODBC Driver 11 for SQL Server};Server=(local)\SQL2016;Database=master;UID=sa;PWD=Password12!;"
         $test_name = "mssql_test"
       } elseif ($env:DB -Match "MySQL") {
-        $env:NANODBC_TEST_CONNSTR_MYSQL="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc_test;User=root;Password=Password12!;"
+        $env:NANODBC_TEST_CONNSTR_MYSQL="Driver={MySQL ODBC 5.3 ANSI Driver};Server=127.0.0.1;Database=nanodbc_test;User=root;Password=Password12!;big_packets=1;"
         $test_name = "mysql_test"
       } elseif ($env:DB -Match "PostgreSQL") {
         $env:NANODBC_TEST_CONNSTR_PGSQL="Driver={PostgreSQL ANSI(x64)};Server=127.0.0.1;Port=5432;Database=nanodbc_test;Uid=postgres;Pwd=Password12!;"

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -65,6 +65,10 @@
 #define SQL_SS_UDT (-151) // from sqlncli.h
 #endif
 
+#ifndef SQL_NVARCHAR
+#define SQL_NVARCHAR (-10)
+#endif
+
 // Default to ODBC version defined by NANODBC_ODBC_VERSION if provided.
 #ifndef NANODBC_ODBC_VERSION
 #ifdef SQL_OV_ODBC3_80
@@ -2489,6 +2493,7 @@ private:
                 break;
             case SQL_CHAR:
             case SQL_VARCHAR:
+            case SQL_NVARCHAR:
                 col.ctype_ = SQL_C_CHAR;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
                 if (is_blob)
@@ -2642,7 +2647,7 @@ inline void result::result_impl::get_ref_impl<string_type>(short column, string_
 {
     bound_column& col = bound_columns_[column];
     const SQLULEN column_size = col.sqlsize_;
-
+    
     switch (col.ctype_)
     {
     case SQL_C_CHAR:

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE_METHOD(mysql_fixture, "test_affected_rows", "[mysql][affected_rows]")
     }
     // Inseting/retrieving long strings
     {
-        std::string long_string(1024, '\0');
+        nanodbc::string_type long_string(1024, '\0');
         for (unsigned i=0; i<1024; i++)
             long_string[i]=(i%64)+32;
         
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(mysql_fixture, "test_affected_rows", "[mysql][affected_rows]")
         REQUIRE(result.affected_rows() == 1);
         
         if (result.next()) {
-            std::string str_from_db = result.get<std::string>(0);
+            nanodbc::string_type str_from_db = result.get<nanodbc::string_type>(0);
             REQUIRE(str_from_db == long_string);
         }
     }


### PR DESCRIPTION
For some reasons, nanodbc does not properly bind and retrieve long strings from/to MySQL (MariaDB). It cuts this strings to first 128 bytes. `blob_test()` does not cover this bug.
#216