### PR TITLE
get_info(), which gets string information from a connection

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -883,80 +883,42 @@ public:
 
     void* native_env_handle() const { return env_; }
 
-    string_type dbms_name() const
+    string_type get_string_info(short info_type) const
     {
-        NANODBC_SQLCHAR name[255] = {0};
+        NANODBC_SQLCHAR value[255] = {0};
         SQLSMALLINT length(0);
         RETCODE rc;
         NANODBC_CALL_RC(
             NANODBC_FUNC(SQLGetInfo),
             rc,
             conn_,
-            SQL_DBMS_NAME,
-            name,
-            sizeof(name) / sizeof(NANODBC_SQLCHAR),
+            info_type,
+            value,
+            sizeof(value) / sizeof(NANODBC_SQLCHAR),
             &length);
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-        return string_type(&name[0], &name[strarrlen(name)]);
+        return string_type(&value[0], &value[strarrlen(value)]);
+    }
+
+    string_type dbms_name() const
+    {
+      return get_string_info(SQL_DBMS_NAME);
     }
 
     string_type dbms_version() const
     {
-        NANODBC_SQLCHAR version[255] = {0};
-        SQLSMALLINT length(0);
-        RETCODE rc;
-        NANODBC_CALL_RC(
-            NANODBC_FUNC(SQLGetInfo),
-            rc,
-            conn_,
-            SQL_DBMS_VER,
-            version,
-            sizeof(version) / sizeof(NANODBC_SQLCHAR),
-            &length);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-        return string_type(&version[0], &version[strarrlen(version)]);
+      return get_string_info(SQL_DBMS_VER);
     }
 
     string_type driver_name() const
     {
-        NANODBC_SQLCHAR name[1024];
-        SQLSMALLINT length;
-        RETCODE rc;
-        NANODBC_CALL_RC(
-            NANODBC_FUNC(SQLGetInfo),
-            rc,
-            conn_,
-            SQL_DRIVER_NAME,
-            name,
-            sizeof(name) / sizeof(NANODBC_SQLCHAR),
-            &length);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-        return string_type(&name[0], &name[strarrlen(name)]);
+      return get_string_info(SQL_DRIVER_NAME);
     }
 
     string_type database_name() const
     {
-        // FIXME: Allocate buffer of dynamic size as drivers do not agree on universal size
-        // MySQL driver limits MAX_NAME_LEN=255
-        // PostgreSQL driver MAX_INFO_STIRNG=128
-        // MFC CDatabase allocates buffer dynamically.
-        NANODBC_SQLCHAR name[255] = {0};
-        SQLSMALLINT length(0);
-        RETCODE rc;
-        NANODBC_CALL_RC(
-            NANODBC_FUNC(SQLGetInfo),
-            rc,
-            conn_,
-            SQL_DATABASE_NAME,
-            name,
-            sizeof(name) / sizeof(NANODBC_SQLCHAR),
-            &length);
-        if (!success(rc))
-            NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-        return string_type(&name[0], &name[strarrlen(name)]);
+      return get_string_info(SQL_DATABASE_NAME);
     }
 
     string_type catalog_name() const
@@ -3208,6 +3170,11 @@ void connection::disconnect()
 std::size_t connection::transactions() const
 {
     return impl_->transactions();
+}
+
+string_type connection::get_string_info(short info_type) const
+{
+    return impl_->get_string_info(info_type);
 }
 
 void* connection::native_dbc_handle() const

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -886,7 +886,7 @@ public:
     template <class T>
     T get_info(short info_type) const
     {
-      return get_info_impl<T>(info_type);
+        return get_info_impl<T>(info_type);
     }
     string_type dbms_name() const;
 
@@ -929,7 +929,7 @@ public:
 
 private:
     template <class T>
-      T get_info_impl(short info_type) const;
+    T get_info_impl(short info_type) const;
 
     HENV env_;
     HDBC conn_;
@@ -941,58 +941,51 @@ private:
 template <class T>
 T connection::connection_impl::get_info_impl(short info_type) const
 {
-  T value;
-  RETCODE rc;
-  NANODBC_CALL_RC(
-      NANODBC_FUNC(SQLGetInfo),
-      rc,
-      conn_,
-      info_type,
-      &value,
-      0,
-      nullptr);
-  if (!success(rc))
-    NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-  return value;
+    T value;
+    RETCODE rc;
+    NANODBC_CALL_RC(NANODBC_FUNC(SQLGetInfo), rc, conn_, info_type, &value, 0, nullptr);
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+    return value;
 }
 
 template <>
 string_type connection::connection_impl::get_info_impl<string_type>(short info_type) const
 {
-  NANODBC_SQLCHAR value[1024] = {0};
-  SQLSMALLINT length(0);
-  RETCODE rc;
-  NANODBC_CALL_RC(
-      NANODBC_FUNC(SQLGetInfo),
-      rc,
-      conn_,
-      info_type,
-      value,
-      sizeof(value) / sizeof(NANODBC_SQLCHAR),
-      &length);
-  if (!success(rc))
-    NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
-  return string_type(&value[0], &value[strarrlen(value)]);
+    NANODBC_SQLCHAR value[1024] = {0};
+    SQLSMALLINT length(0);
+    RETCODE rc;
+    NANODBC_CALL_RC(
+        NANODBC_FUNC(SQLGetInfo),
+        rc,
+        conn_,
+        info_type,
+        value,
+        sizeof(value) / sizeof(NANODBC_SQLCHAR),
+        &length);
+    if (!success(rc))
+        NANODBC_THROW_DATABASE_ERROR(conn_, SQL_HANDLE_DBC);
+    return string_type(&value[0], &value[strarrlen(value)]);
 }
 
 string_type connection::connection_impl::dbms_name() const
 {
-  return get_info<string_type>(SQL_DBMS_NAME);
+    return get_info<string_type>(SQL_DBMS_NAME);
 }
 
 string_type connection::connection_impl::dbms_version() const
 {
-  return get_info<string_type>(SQL_DBMS_VER);
+    return get_info<string_type>(SQL_DBMS_VER);
 }
 
 string_type connection::connection_impl::driver_name() const
 {
-  return get_info<string_type>(SQL_DRIVER_NAME);
+    return get_info<string_type>(SQL_DRIVER_NAME);
 }
 
 string_type connection::connection_impl::database_name() const
 {
-  return get_info<string_type>(SQL_DATABASE_NAME);
+    return get_info<string_type>(SQL_DATABASE_NAME);
 }
 
 template string_type connection::get_info(short info_type) const;

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1019,6 +1019,10 @@ public:
     /// \brief Returns the native ODBC environment handle.
     void* native_env_handle() const;
 
+
+    /// \brief Returns information from the ODBC connection as a string.
+    string_type get_string_info(short info_type) const;
+
     /// \brief Returns name of the DBMS product.
     /// Returns the ODBC information type SQL_DBMS_NAME of the DBMS product
     /// accesssed by the driver via the current connection.

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1019,9 +1019,8 @@ public:
     /// \brief Returns the native ODBC environment handle.
     void* native_env_handle() const;
 
-
     /// \brief Returns information from the ODBC connection as a string.
-    template<class T>
+    template <class T>
     T get_info(short info_type) const;
 
     /// \brief Returns name of the DBMS product.
@@ -1337,10 +1336,10 @@ class result_iterator
 {
 public:
     typedef std::input_iterator_tag iterator_category; ///< Category of iterator.
-    typedef result value_type; ///< Values returned by iterator access.
-    typedef result* pointer; ///< Pointer to iteration values.
-    typedef result& reference; ///< Reference to iteration values.
-    typedef std::ptrdiff_t difference_type; ///< Iterator difference.
+    typedef result value_type;                         ///< Values returned by iterator access.
+    typedef result* pointer;                           ///< Pointer to iteration values.
+    typedef result& reference;                         ///< Reference to iteration values.
+    typedef std::ptrdiff_t difference_type;            ///< Iterator difference.
 
     /// Default iterator; an empty result set.
     result_iterator() = default;
@@ -1447,11 +1446,11 @@ public:
     class tables
     {
     public:
-        bool next(); ///< Move to the next result in the result set.
+        bool next();                       ///< Move to the next result in the result set.
         string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const; ///< Fetch table schema.
-        string_type table_name() const; ///< Fetch table name.
-        string_type table_type() const; ///< Fetch table type.
+        string_type table_schema() const;  ///< Fetch table schema.
+        string_type table_name() const;    ///< Fetch table name.
+        string_type table_type() const;    ///< Fetch table type.
         string_type table_remarks() const; ///< Fetch table remarks.
 
     private:
@@ -1464,23 +1463,23 @@ public:
     class columns
     {
     public:
-        bool next(); ///< Move to the next result in the result set.
-        string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const; ///< Fetch table schema.
-        string_type table_name() const; ///< Fetch table name.
-        string_type column_name() const; ///< Fetch column name.
-        short data_type() const; ///< Fetch column data type.
-        string_type type_name() const; ///< Fetch column type name.
-        long column_size() const; ///< Fetch column size.
-        long buffer_length() const; ///< Fetch buffer length.
-        short decimal_digits() const; ///< Fetch decimal digits.
+        bool next();                           ///< Move to the next result in the result set.
+        string_type table_catalog() const;     ///< Fetch table catalog.
+        string_type table_schema() const;      ///< Fetch table schema.
+        string_type table_name() const;        ///< Fetch table name.
+        string_type column_name() const;       ///< Fetch column name.
+        short data_type() const;               ///< Fetch column data type.
+        string_type type_name() const;         ///< Fetch column type name.
+        long column_size() const;              ///< Fetch column size.
+        long buffer_length() const;            ///< Fetch buffer length.
+        short decimal_digits() const;          ///< Fetch decimal digits.
         short numeric_precision_radix() const; ///< Fetch numeric precission.
-        short nullable() const; ///< True iff column is nullable.
-        string_type remarks() const; ///< Fetch column remarks.
-        string_type column_default() const; ///< Fetch column's default.
-        short sql_data_type() const; ///< Fetch column's SQL data type.
-        short sql_datetime_subtype() const; ///< Fetch datetime subtype of column.
-        long char_octet_length() const; ///< Fetch char octet length.
+        short nullable() const;                ///< True iff column is nullable.
+        string_type remarks() const;           ///< Fetch column remarks.
+        string_type column_default() const;    ///< Fetch column's default.
+        short sql_data_type() const;           ///< Fetch column's SQL data type.
+        short sql_datetime_subtype() const;    ///< Fetch datetime subtype of column.
+        long char_octet_length() const;        ///< Fetch char octet length.
 
         /// \brief Ordinal position of the column in the table.
         /// The first column in the table is number 1.
@@ -1504,11 +1503,11 @@ public:
     class primary_keys
     {
     public:
-        bool next(); ///< Move to the next result in the result set.
+        bool next();                       ///< Move to the next result in the result set.
         string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const; ///< Fetch table schema.
-        string_type table_name() const; ///< Fetch table name.
-        string_type column_name() const; ///< Fetch column name.
+        string_type table_schema() const;  ///< Fetch table schema.
+        string_type table_name() const;    ///< Fetch table name.
+        string_type column_name() const;   ///< Fetch column name.
 
         /// \brief Column sequence number in the key (starting with 1).
         /// Returns valye of KEY_SEQ column in result set returned by SQLPrimaryKeys.
@@ -1529,13 +1528,13 @@ public:
     class table_privileges
     {
     public:
-        bool next(); ///< Move to the next result in the result set
+        bool next();                       ///< Move to the next result in the result set
         string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const; ///< Fetch table schema.
-        string_type table_name() const; ///< Fetch table name.
-        string_type grantor() const; ///< Fetch name of user who granted the privilege.
-        string_type grantee() const; ///< Fetch name of user whom the privilege was granted.
-        string_type privilege() const; ///< Fetch the table privilege.
+        string_type table_schema() const;  ///< Fetch table schema.
+        string_type table_name() const;    ///< Fetch table name.
+        string_type grantor() const;       ///< Fetch name of user who granted the privilege.
+        string_type grantee() const;       ///< Fetch name of user whom the privilege was granted.
+        string_type privilege() const;     ///< Fetch the table privilege.
         /// Fetch indicator whether the grantee is permitted to grant the privilege to other users.
         string_type is_grantable() const;
 
@@ -1570,7 +1569,8 @@ public:
     /// result set ordered by TABLE_CAT, TABLE_SCHEM, TABLE_NAME, PRIVILEGE, and GRANTEE.
     ///
     /// \param catalog The table catalog. It cannot contain a string search pattern.
-    /// \param schema String search pattern for schema names, treated as the Pattern Value Arguments.
+    /// \param schema String search pattern for schema names, treated as the Pattern Value
+    /// Arguments.
     /// \param table String search pattern for table names, treated as the Pattern Value Arguments.
     ///
     /// \note Due to the fact catalog cannot is not the Pattern Value Argument,
@@ -1648,10 +1648,10 @@ struct driver
     struct attribute
     {
         nanodbc::string_type keyword; ///< Driver keyword attribute.
-        nanodbc::string_type value; ///< Driver attribute value.
+        nanodbc::string_type value;   ///< Driver attribute value.
     };
 
-    nanodbc::string_type name; ///< Driver name.
+    nanodbc::string_type name;       ///< Driver name.
     std::list<attribute> attributes; ///< List of driver attributes.
 };
 

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1021,7 +1021,8 @@ public:
 
 
     /// \brief Returns information from the ODBC connection as a string.
-    string_type get_string_info(short info_type) const;
+    template<class T>
+    T get_info(short info_type) const;
 
     /// \brief Returns name of the DBMS product.
     /// Returns the ODBC information type SQL_DBMS_NAME of the DBMS product

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -1021,8 +1021,11 @@ struct base_test_fixture
         REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_DRIVER_NAME).empty());
         REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_ODBC_VER).empty());
 
-       // Test SQLUSMALLINT resutls
-        REQUIRE(connection.get_info<unsigned short>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
+       // Test SQLUSMALLINT results
+        REQUIRE(connection.get_info<unsigned short>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
+
+        // Test SQUINTEGER results
+        REQUIRE(connection.get_info<uint32_t>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
 
         // Test SQUINTEGER bitmask results
         REQUIRE((connection.get_info<uint32_t>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -1012,6 +1012,15 @@ struct base_test_fixture
         REQUIRE(!connection.dbms_version().empty());
     }
 
+    void get_string_info_test()
+    {
+        // A generic test to exercise the DBMS info API is callable.
+        // DBMS-specific test (MySQL, SQLite, etc.) may perform extended checks.
+        nanodbc::connection connection = connect();
+        REQUIRE(!connection.get_string_info(SQL_DRIVER_NAME).empty());
+        REQUIRE(!connection.get_string_info(SQL_ODBC_VER).empty());
+    }
+
     void decimal_conversion_test()
     {
         nanodbc::connection connection = connect();

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -1,6 +1,7 @@
 #ifndef NANODBC_TEST_BASE_TEST_FIXTURE_H
 #define NANODBC_TEST_BASE_TEST_FIXTURE_H
 
+#include <iostream>
 #include "nanodbc.h"
 #include <cassert>
 #include <tuple>
@@ -1012,13 +1013,22 @@ struct base_test_fixture
         REQUIRE(!connection.dbms_version().empty());
     }
 
-    void get_string_info_test()
+    void get_info_test()
     {
         // A generic test to exercise the DBMS info API is callable.
         // DBMS-specific test (MySQL, SQLite, etc.) may perform extended checks.
         nanodbc::connection connection = connect();
-        REQUIRE(!connection.get_string_info(SQL_DRIVER_NAME).empty());
-        REQUIRE(!connection.get_string_info(SQL_ODBC_VER).empty());
+        REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_DRIVER_NAME).empty());
+        REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_ODBC_VER).empty());
+
+       // Test SQLUSMALLINT resutls
+        REQUIRE(connection.get_info<unsigned short>(SQL_ODBC_INTERFACE_CONFORMANCE) > 0);
+
+        // Test SQUINTEGER bitmask results
+        REQUIRE((connection.get_info<uint32_t>(SQL_CREATE_TABLE) & SQL_CT_CREATE_TABLE));
+
+        // Test SQLULEN results
+        REQUIRE(connection.get_info<uint64_t>(SQL_DRIVER_HDBC) > 0);
     }
 
     void decimal_conversion_test()

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -297,6 +297,11 @@ TEST_CASE_METHOD(mssql_fixture, "dbms_info_test", "[mssql][dmbs][metadata][info]
     dbms_info_test();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "get_info_test", "[mssql][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "decimal_conversion_test", "[mssql][decimal][conversion]")
 {
     decimal_conversion_test();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -111,6 +111,11 @@ TEST_CASE_METHOD(mysql_fixture, "dbms_info_test", "[mysql][dmbs][metadata][info]
     dbms_info_test();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "get_info_test", "[mysql][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "decimal_conversion_test", "[mysql][decimal][conversion]")
 {
     decimal_conversion_test();

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -60,7 +60,7 @@ TEST_CASE_METHOD(odbc_fixture, "dbms_info_test", "[odbc][dmbs][metadata][info]")
     dbms_info_test();
 }
 
-T_CASE_METHOD(odbc_fixture, "get_info_test", "[odbc][dmbs][metadata][info]")
+TEST_CASE_METHOD(odbc_fixture, "get_info_test", "[odbc][dmbs][metadata][info]")
 {
     get_info_test();
 }

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -60,6 +60,11 @@ TEST_CASE_METHOD(odbc_fixture, "dbms_info_test", "[odbc][dmbs][metadata][info]")
     dbms_info_test();
 }
 
+T_CASE_METHOD(odbc_fixture, "get_info_test", "[odbc][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "decimal_conversion_test", "[odbc][decimal][conversion]")
 {
     decimal_conversion_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -76,6 +76,11 @@ TEST_CASE_METHOD(postgresql_fixture, "dbms_info_test", "[postgresql][dmbs][metad
     dbms_info_test();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "get_info_test", "[postgresql][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "decimal_conversion_test", "[postgresql][decimal][conversion]")
 {
     decimal_conversion_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -178,6 +178,11 @@ TEST_CASE_METHOD(sqlite_fixture, "dbms_info_test", "[sqlite][dmbs][metadata][inf
     REQUIRE(connection.dbms_name() == NANODBC_TEXT("SQLite"));
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "get_info_test", "[sqlite][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "decimal_conversion_test", "[sqlite][decimal][conversion]")
 {
     // SQLite ODBC driver requires dedicated test.

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -57,6 +57,11 @@ TEST_CASE_METHOD(vertica_fixture, "dbms_info_test", "[vertica][dmbs][metadata][i
     dbms_info_test();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "get_info_test", "[vertica][dmbs][metadata][info]")
+{
+    get_info_test();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "decimal_conversion_test", "[vertica][decimal][conversion]")
 {
     decimal_conversion_test();


### PR DESCRIPTION
This exposes a simple function that takes an info_type returns the information as a string, which allows users to query all available info types (https://msdn.microsoft.com/en-us/library/ms711681(v=vs.85).aspx#Anchor_6) not just those exposed by nanodbc methods.