### PR TITLE
Add nanodbc::char_type typedef

### DIFF
--- a/examples/usage.cpp
+++ b/examples/usage.cpp
@@ -96,7 +96,7 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const size_t elements = 4;
 
-        nanodbc::string_type::value_type xdata[elements][10] = {
+        nanodbc::char_type xdata[elements][10] = {
             NANODBC_TEXT("this"), NANODBC_TEXT("is"), NANODBC_TEXT("a"), NANODBC_TEXT("test")};
         statement.bind_strings(0, xdata);
 
@@ -139,13 +139,13 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const int elements = 5;
         const int a_null = 0;
-        nanodbc::string_type::value_type const* b_null = NANODBC_TEXT("");
+        nanodbc::char_type const* b_null = NANODBC_TEXT("");
         int a_data[elements] = {0, 88, 0, 0, 0};
-        nanodbc::string_type::value_type b_data[elements][10] = {NANODBC_TEXT(""),
-                                                                 NANODBC_TEXT("non-null"),
-                                                                 NANODBC_TEXT(""),
-                                                                 NANODBC_TEXT(""),
-                                                                 NANODBC_TEXT("")};
+        nanodbc::char_type b_data[elements][10] = {NANODBC_TEXT(""),
+                                                   NANODBC_TEXT("non-null"),
+                                                   NANODBC_TEXT(""),
+                                                   NANODBC_TEXT(""),
+                                                   NANODBC_TEXT("")};
 
         statement.bind(0, a_data, elements, &a_null);
         statement.bind_strings(1, b_data, b_null);
@@ -163,8 +163,7 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const int elements = 2;
         int a_data[elements] = {0, 42};
-        nanodbc::string_type::value_type b_data[elements][10] = {
-            NANODBC_TEXT(""), NANODBC_TEXT("every")};
+        nanodbc::char_type b_data[elements][10] = {NANODBC_TEXT(""), NANODBC_TEXT("every")};
         bool nulls[elements] = {true, false};
 
         statement.bind(0, a_data, elements, nulls);

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -365,6 +365,8 @@ recent_error(SQLHANDLE handle, SQLSMALLINT handle_type, long& native, std::strin
 namespace nanodbc
 {
 
+static_assert(sizeof(string_type::value_type) == sizeof(char_type), "invalid char_type size");
+
 type_incompatible_error::type_incompatible_error()
     : std::runtime_error("type incompatible")
 {

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -156,6 +156,7 @@ typedef std::u16string string_type;
 typedef std::string string_type;
 #define NANODBC_TEXT(s) s
 #endif
+typedef string_type::value_type char_type;
 
 #if defined(_WIN64)
 // LLP64 machine: Windows


### PR DESCRIPTION
The `char_type` alias complements `string_type` for convenient access to character type expected by nanodbc interface which depends on build configurations.

---

TODO:
- Shall we also assume `sizeof(NANODBC_SQLCHAR) == sizeof(char_type)` ?
