### PR TITLE
Implement batch binary inputs

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1748,23 +1748,22 @@ public:
         const bool* nulls = nullptr,
         const uint8_t* null_sentry = nullptr)
     {
-      std::size_t batch_size = values.size();
-      bound_parameter param;
-      prepare_bind(param_index, batch_size, direction, param);
+        std::size_t batch_size = values.size();
+        bound_parameter param;
+        prepare_bind(param_index, batch_size, direction, param);
 
         size_t max_length = 0;
         for (std::size_t i = 0; i < batch_size; ++i)
         {
-            if (values[i].size() > max_length)
-            {
-                max_length = values[i].size();
-            }
+            max_length = std::max(values[i].size(), max_length);
         }
         binary_data_[param_index] = std::vector<uint8_t>(batch_size * max_length, 0);
         for (std::size_t i = 0; i < batch_size; ++i)
         {
             std::copy(
-                values[i].begin(), values[i].end(), binary_data_[param_index].data() + (i * max_length));
+                values[i].begin(),
+                values[i].end(),
+                binary_data_[param_index].data() + (i * max_length));
         }
 
         if (null_sentry)

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1741,52 +1741,60 @@ public:
         string_type::value_type const* null_sentry = nullptr);
 
     // handles multiple binary values
-    void bind(short param, const std::vector<std::vector<uint8_t>> & values, const bool* nulls, const uint8_t* null_sentry, param_direction direction)
+    void bind(
+        short param,
+        const std::vector<std::vector<uint8_t>>& values,
+        const bool* nulls,
+        const uint8_t* null_sentry,
+        param_direction direction)
     {
-      SQLSMALLINT data_type;
-      SQLSMALLINT param_type;
-      SQLULEN parameter_size;
-      SQLSMALLINT scale;
-      const size_t elements = values.size();
-      prepare_bind(param, elements, direction, data_type, param_type, parameter_size, scale);
+        SQLSMALLINT data_type;
+        SQLSMALLINT param_type;
+        SQLULEN parameter_size;
+        SQLSMALLINT scale;
+        const size_t elements = values.size();
+        prepare_bind(param, elements, direction, data_type, param_type, parameter_size, scale);
 
-      size_t max_len = 0;
-      for (std::size_t i = 0; i < elements; ++i)
-      {
-        if (values[i].size() > max_len)
+        size_t max_len = 0;
+        for (std::size_t i = 0; i < elements; ++i)
         {
-          max_len = values[i].size();
+            if (values[i].size() > max_len)
+            {
+                max_len = values[i].size();
+            }
         }
-      }
-      binary_data_[param] = std::vector<uint8_t>(elements * max_len, 0);
-      for (std::size_t i = 0; i < elements; ++i)
-      {
-        std::copy(values[i].begin(), values[i].end(), binary_data_[param].data() + (i * max_len));
-      }
+        binary_data_[param] = std::vector<uint8_t>(elements * max_len, 0);
+        for (std::size_t i = 0; i < elements; ++i)
+        {
+            std::copy(
+                values[i].begin(), values[i].end(), binary_data_[param].data() + (i * max_len));
+        }
 
-      if (null_sentry)
-      {
-        for (std::size_t i = 0; i < elements; ++i)
-          if (!std::equal(values[i].begin(), values[i].end(), null_sentry))
-          {
-            bind_len_or_null_[param][i] = values[i].size();
-          }
-      }
-      else if (nulls)
-      {
-        for (std::size_t i = 0; i < elements; ++i)
+        if (null_sentry)
         {
-          if (!nulls[i])
-            bind_len_or_null_[param][i] = values[i].size(); // null terminated
+            for (std::size_t i = 0; i < elements; ++i)
+                if (!std::equal(values[i].begin(), values[i].end(), null_sentry))
+                {
+                    bind_len_or_null_[param][i] = values[i].size();
+                }
         }
-      }
-      else {
-        for (std::size_t i = 0; i < elements; ++i)
+        else if (nulls)
         {
-          bind_len_or_null_[param][i] = values[i].size();
+            for (std::size_t i = 0; i < elements; ++i)
+            {
+                if (!nulls[i])
+                    bind_len_or_null_[param][i] = values[i].size(); // null terminated
+            }
         }
-      }
-      bind_parameter(param, binary_data_[param].data(), elements, data_type, param_type, max_len, scale);
+        else
+        {
+            for (std::size_t i = 0; i < elements; ++i)
+            {
+                bind_len_or_null_[param][i] = values[i].size();
+            }
+        }
+        bind_parameter(
+            param, binary_data_[param].data(), elements, data_type, param_type, max_len, scale);
     }
 
     // handles multiple null values
@@ -3746,7 +3754,7 @@ void statement::bind(
 
 void statement::bind(
     short param,
-    const std::vector<std::vector<uint8_t>> & values,
+    const std::vector<std::vector<uint8_t>>& values,
     param_direction direction)
 {
     impl_->bind(param, values, (bool*)0, (uint8_t*)0, direction);
@@ -3754,7 +3762,7 @@ void statement::bind(
 
 void statement::bind(
     short param,
-    const std::vector<std::vector<uint8_t>> & values,
+    const std::vector<std::vector<uint8_t>>& values,
     const bool* nulls,
     param_direction direction)
 {
@@ -3763,7 +3771,7 @@ void statement::bind(
 
 void statement::bind(
     short param,
-    const std::vector<std::vector<uint8_t>> & values,
+    const std::vector<std::vector<uint8_t>>& values,
     const uint8_t* null_sentry,
     param_direction direction)
 {

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1742,59 +1742,56 @@ public:
 
     // handles multiple binary values
     void bind(
-        short param,
+        param_direction direction,
+        short param_index,
         const std::vector<std::vector<uint8_t>>& values,
-        const bool* nulls,
-        const uint8_t* null_sentry,
-        param_direction direction)
+        const bool* nulls = nullptr,
+        const uint8_t* null_sentry = nullptr)
     {
-        SQLSMALLINT data_type;
-        SQLSMALLINT param_type;
-        SQLULEN parameter_size;
-        SQLSMALLINT scale;
-        const size_t elements = values.size();
-        prepare_bind(param, elements, direction, data_type, param_type, parameter_size, scale);
+      std::size_t batch_size = values.size();
+      bound_parameter param;
+      prepare_bind(param_index, batch_size, direction, param);
 
-        size_t max_len = 0;
-        for (std::size_t i = 0; i < elements; ++i)
+        size_t max_length = 0;
+        for (std::size_t i = 0; i < batch_size; ++i)
         {
-            if (values[i].size() > max_len)
+            if (values[i].size() > max_length)
             {
-                max_len = values[i].size();
+                max_length = values[i].size();
             }
         }
-        binary_data_[param] = std::vector<uint8_t>(elements * max_len, 0);
-        for (std::size_t i = 0; i < elements; ++i)
+        binary_data_[param_index] = std::vector<uint8_t>(batch_size * max_length, 0);
+        for (std::size_t i = 0; i < batch_size; ++i)
         {
             std::copy(
-                values[i].begin(), values[i].end(), binary_data_[param].data() + (i * max_len));
+                values[i].begin(), values[i].end(), binary_data_[param_index].data() + (i * max_length));
         }
 
         if (null_sentry)
         {
-            for (std::size_t i = 0; i < elements; ++i)
+            for (std::size_t i = 0; i < batch_size; ++i)
                 if (!std::equal(values[i].begin(), values[i].end(), null_sentry))
                 {
-                    bind_len_or_null_[param][i] = values[i].size();
+                    bind_len_or_null_[param_index][i] = values[i].size();
                 }
         }
         else if (nulls)
         {
-            for (std::size_t i = 0; i < elements; ++i)
+            for (std::size_t i = 0; i < batch_size; ++i)
             {
                 if (!nulls[i])
-                    bind_len_or_null_[param][i] = values[i].size(); // null terminated
+                    bind_len_or_null_[param_index][i] = values[i].size(); // null terminated
             }
         }
         else
         {
-            for (std::size_t i = 0; i < elements; ++i)
+            for (std::size_t i = 0; i < batch_size; ++i)
             {
-                bind_len_or_null_[param][i] = values[i].size();
+                bind_len_or_null_[param_index][i] = values[i].size();
             }
         }
-        bind_parameter(
-            param, binary_data_[param].data(), elements, data_type, param_type, max_len, scale);
+        bound_buffer<uint8_t> buffer(binary_data_[param_index].data(), batch_size, max_length);
+        bind_parameter(param, buffer);
     }
 
     // handles multiple null values
@@ -3753,29 +3750,29 @@ void statement::bind(
 }
 
 void statement::bind(
-    short param,
+    short param_index,
     const std::vector<std::vector<uint8_t>>& values,
     param_direction direction)
 {
-    impl_->bind(param, values, (bool*)0, (uint8_t*)0, direction);
+    impl_->bind(direction, param_index, values, (bool*)0, (uint8_t*)0);
 }
 
 void statement::bind(
-    short param,
+    short param_index,
     const std::vector<std::vector<uint8_t>>& values,
     const bool* nulls,
     param_direction direction)
 {
-    impl_->bind(param, values, nulls, (uint8_t*)0, direction);
+    impl_->bind(direction, param_index, values, nulls, (uint8_t*)0);
 }
 
 void statement::bind(
-    short param,
+    short param_index,
     const std::vector<std::vector<uint8_t>>& values,
     const uint8_t* null_sentry,
     param_direction direction)
 {
-    impl_->bind(param, values, (bool*)0, null_sentry, direction);
+    impl_->bind(direction, param_index, values, (bool*)0, null_sentry);
 }
 
 void statement::bind_strings(

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -3744,6 +3744,32 @@ void statement::bind(
     impl_->bind(direction, param_index, values, batch_size, nulls, (T*)0);
 }
 
+void statement::bind(
+    short param,
+    const std::vector<std::vector<uint8_t>> & values,
+    param_direction direction)
+{
+    impl_->bind(param, values, (bool*)0, (uint8_t*)0, direction);
+}
+
+void statement::bind(
+    short param,
+    const std::vector<std::vector<uint8_t>> & values,
+    const bool* nulls,
+    param_direction direction)
+{
+    impl_->bind(param, values, nulls, (uint8_t*)0, direction);
+}
+
+void statement::bind(
+    short param,
+    const std::vector<std::vector<uint8_t>> & values,
+    const uint8_t* null_sentry,
+    param_direction direction)
+{
+    impl_->bind(param, values, (bool*)0, null_sentry, direction);
+}
+
 void statement::bind_strings(
     short param_index,
     std::vector<string_type> const& values,

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -754,6 +754,29 @@ public:
         bool const* nulls,
         param_direction direction = PARAM_IN);
 
+    /// \brief Binds multiple values.
+    /// \see bind_multi
+    void bind(
+        short param,
+        const std::vector<std::vector<uint8_t>> & values,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds multiple values.
+    /// \see bind_multi
+    void bind(
+        short param,
+        const std::vector<std::vector<uint8_t>> & values,
+        const bool* nulls,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds multiple values.
+    /// \see bind_multi
+    void bind(
+        short param,
+        const std::vector<std::vector<uint8_t>> & values,
+        const uint8_t* null_sentry,
+        param_direction direction = PARAM_IN);
+
     /// @}
 
     /// \addtogroup bind_strings Binding multiple string values

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -758,14 +758,14 @@ public:
     /// \see bind_multi
     void bind(
         short param,
-        const std::vector<std::vector<uint8_t>> & values,
+        const std::vector<std::vector<uint8_t>>& values,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple values.
     /// \see bind_multi
     void bind(
         short param,
-        const std::vector<std::vector<uint8_t>> & values,
+        const std::vector<std::vector<uint8_t>>& values,
         const bool* nulls,
         param_direction direction = PARAM_IN);
 
@@ -773,7 +773,7 @@ public:
     /// \see bind_multi
     void bind(
         short param,
-        const std::vector<std::vector<uint8_t>> & values,
+        const std::vector<std::vector<uint8_t>>& values,
         const uint8_t* null_sentry,
         param_direction direction = PARAM_IN);
 

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -1773,7 +1773,7 @@ struct base_test_fixture
 
         drop_table(connection, NANODBC_TEXT("batch_binary_test"));
         nanodbc::string_type const binary_type_name = get_binary_type_name();
-        execute(connection, NANODBC_TEXT("create table batch_binary_test (s ") + binary_type_name + NANODBC_TEXT(")"));
+        execute(connection, NANODBC_TEXT("create table batch_binary_test (s ") + binary_type_name + NANODBC_TEXT("(10))"));
         nanodbc::statement query(connection);
         prepare(query, NANODBC_TEXT("insert into batch_binary_test(s) values(?)"));
         query.bind(0, data);

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -380,9 +380,9 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_vector", "[mssql][string]")
     test_string_vector();
 }
 
-TEST_CASE_METHOD(mssql_fixture, "batch_binary_test", "[mssql][binary]")
+TEST_CASE_METHOD(mssql_fixture, "test_batch_binary", "[mssql][binary]")
 {
-    batch_binary_test();
+    test_batch_binary();
 }
 
 TEST_CASE_METHOD(mssql_fixture, "test_transaction", "[mssql][transaction]")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -380,6 +380,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_string_vector", "[mssql][string]")
     test_string_vector();
 }
 
+TEST_CASE_METHOD(mssql_fixture, "batch_binary_test", "[mssql][binary]")
+{
+    batch_binary_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_transaction", "[mssql][transaction]")
 {
     test_transaction();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -191,6 +191,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_string_vector", "[mysql][string]")
     test_string_vector();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "batch_binary_test", "[mysql][binary]")
+{
+    batch_binary_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_transaction", "[mysql][transaction]")
 {
     test_transaction();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -191,9 +191,9 @@ TEST_CASE_METHOD(mysql_fixture, "test_string_vector", "[mysql][string]")
     test_string_vector();
 }
 
-TEST_CASE_METHOD(mysql_fixture, "batch_binary_test", "[mysql][binary]")
+TEST_CASE_METHOD(mysql_fixture, "test_batch_binary", "[mysql][binary]")
 {
-    batch_binary_test();
+    test_batch_binary();
 }
 
 TEST_CASE_METHOD(mysql_fixture, "test_transaction", "[mysql][transaction]")

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -125,9 +125,9 @@ TEST_CASE_METHOD(odbc_fixture, "test_string_vector", "[odbc][string]")
     test_string_vector();
 }
 
-TEST_CASE_METHOD(odbc_fixture, "batch_binary_test", "[odbc][binary]")
+TEST_CASE_METHOD(odbc_fixture, "test_batch_binary", "[odbc][binary]")
 {
-    batch_binary_test();
+    test_batch_binary();
 }
 
 TEST_CASE_METHOD(odbc_fixture, "test_transaction", "[odbc][transaction]")

--- a/test/odbc_test.cpp
+++ b/test/odbc_test.cpp
@@ -125,6 +125,11 @@ TEST_CASE_METHOD(odbc_fixture, "test_string_vector", "[odbc][string]")
     test_string_vector();
 }
 
+TEST_CASE_METHOD(odbc_fixture, "batch_binary_test", "[odbc][binary]")
+{
+    batch_binary_test();
+}
+
 TEST_CASE_METHOD(odbc_fixture, "test_transaction", "[odbc][transaction]")
 {
     test_transaction();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -154,6 +154,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_string_vector", "[postgresql][string]
     test_string_vector();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_batch_binary", "[postgresql][binary]")
+{
+    test_batch_binary();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_transaction", "[postgresql][transaction]")
 {
     test_transaction();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -419,6 +419,11 @@ TEST_CASE_METHOD(sqlite_fixture, "test_string_vector", "[sqlite][string]")
     test_string_vector();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "batch_binary_test", "[sqlite][binary]")
+{
+    batch_binary_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "test_time", "[sqlite][time]")
 {
     test_time();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -419,9 +419,9 @@ TEST_CASE_METHOD(sqlite_fixture, "test_string_vector", "[sqlite][string]")
     test_string_vector();
 }
 
-TEST_CASE_METHOD(sqlite_fixture, "batch_binary_test", "[sqlite][binary]")
+TEST_CASE_METHOD(sqlite_fixture, "test_batch_binary", "[sqlite][binary]")
 {
-    batch_binary_test();
+    test_batch_binary();
 }
 
 TEST_CASE_METHOD(sqlite_fixture, "test_time", "[sqlite][time]")

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -140,6 +140,11 @@ TEST_CASE_METHOD(vertica_fixture, "test_transaction", "[vertica][transaction]")
     test_transaction();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "batch_binary_test", "[vertica][binary]")
+{
+    batch_binary_test();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "test_while_not_end_iteration", "[vertica][looping]")
 {
     test_while_not_end_iteration();

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -140,9 +140,9 @@ TEST_CASE_METHOD(vertica_fixture, "test_transaction", "[vertica][transaction]")
     test_transaction();
 }
 
-TEST_CASE_METHOD(vertica_fixture, "batch_binary_test", "[vertica][binary]")
+TEST_CASE_METHOD(vertica_fixture, "test_batch_binary", "[vertica][binary]")
 {
-    batch_binary_test();
+    test_batch_binary();
 }
 
 TEST_CASE_METHOD(vertica_fixture, "test_while_not_end_iteration", "[vertica][looping]")


### PR DESCRIPTION
Similar to https://github.com/lexicalunit/nanodbc/pull/214 this adds binding support for `std::vector<std::vector<uint8_t>>` inputs, which allows you to bind batches of arbitrary binary data. We could not use the `bind_strings()` for this as there could be embedded nulls in the data, as pointed out by https://github.com/lexicalunit/nanodbc/issues/209.
