### PR TITLE
Fix and clean up bind family of functions

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -5,7 +5,7 @@
 // Generated with http://patorjk.com/software/taag/#p=display&v=0&f=Colossal
 
 #if defined(_MSC_VER)
-# if _MSC_VER <= 1800
+#if _MSC_VER <= 1800
 // silence spurious Visual C++ warnings
 #pragma warning(disable : 4244) // warning about integer conversion issues.
 #pragma warning(disable : 4312) // warning about 64-bit portability issues.
@@ -599,11 +599,11 @@ struct bound_parameter
 {
     bound_parameter() = default;
 
-    SQLUSMALLINT index_ = 0;    // Zero-based index of parameter marker
-    SQLSMALLINT iotype_ = 0;    // Input/Output type of parameter
-    SQLSMALLINT type_ = 0;      // SQL data type of parameter
-    SQLULEN     size_ = 0;      // SQL data size of column or expression inbytes or characters
-    SQLSMALLINT scale_ = 0;     // decimal digits of column or expression
+    SQLUSMALLINT index_ = 0; // Zero-based index of parameter marker
+    SQLSMALLINT iotype_ = 0; // Input/Output type of parameter
+    SQLSMALLINT type_ = 0;   // SQL data type of parameter
+    SQLULEN size_ = 0;       // SQL data size of column or expression inbytes or characters
+    SQLSMALLINT scale_ = 0;  // decimal digits of column or expression
 };
 
 // Encapsulates properties of buffer with data values bound to statement parameter.
@@ -612,11 +612,15 @@ struct bound_buffer
 {
     bound_buffer() = default;
     bound_buffer(T const* values, std::size_t size, std::size_t value_size = 0)
-        : values_(values), size_(size), value_size_(value_size) {}
+        : values_(values)
+        , size_(size)
+        , value_size_(value_size)
+    {
+    }
 
-    T const* values_ = nullptr; // Pointer to buffer for parameter's data
-    std::size_t size_ = 0;      // Number of values (1 or length of array)
-    std::size_t value_size_ = 0;// Size of single value (max size). Zero, if ignored.
+    T const* values_ = nullptr;  // Pointer to buffer for parameter's data
+    std::size_t size_ = 0;       // Number of values (1 or length of array)
+    std::size_t value_size_ = 0; // Size of single value (max size). Zero, if ignored.
 };
 
 // Allocates the native ODBC handles.
@@ -1584,7 +1588,7 @@ public:
 
     void reset_parameters() NANODBC_NOEXCEPT { NANODBC_CALL(SQLFreeStmt, stmt_, SQL_RESET_PARAMS); }
 
-    unsigned long parameter_size(short param) const
+    unsigned long parameter_size(short param_index) const
     {
         RETCODE rc;
         SQLSMALLINT data_type;
@@ -1596,7 +1600,7 @@ public:
 #endif
 
         NANODBC_CALL_RC(
-            SQLDescribeParam, rc, stmt_, param + 1, &data_type, &parameter_size, 0, &nullable);
+            SQLDescribeParam, rc, stmt_, param_index + 1, &data_type, &parameter_size, 0, &nullable);
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
         NANODBC_ASSERT(
@@ -1627,7 +1631,11 @@ public:
     }
 
     // initializes bind_len_or_null_ and gets information for bind
-    void prepare_bind(short param_index, std::size_t elements, param_direction direction, bound_parameter& param)
+    void prepare_bind(
+        short param_index,
+        std::size_t batch_size,
+        param_direction direction,
+        bound_parameter& param)
     {
         NANODBC_ASSERT(param_index >= 0);
 
@@ -1638,7 +1646,14 @@ public:
         RETCODE rc;
         SQLSMALLINT nullable; // unused
         NANODBC_CALL_RC(
-            SQLDescribeParam, rc, stmt_, param_index + 1, &param.type_, &param.size_, &param.scale_, &nullable);
+            SQLDescribeParam,
+            rc,
+            stmt_,
+            param_index + 1,
+            &param.type_,
+            &param.size_,
+            &param.scale_,
+            &nullable);
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
 
@@ -1650,7 +1665,7 @@ public:
         std::vector<null_type>().swap(bind_len_or_null_[param_index]);
 
         // ODBC weirdness: this must be at least 8 elements in size
-        const std::size_t indicator_size = elements > 8 ? elements : 8;
+        const std::size_t indicator_size = batch_size > 8 ? batch_size : 8;
         bind_len_or_null_[param_index].reserve(indicator_size);
         bind_len_or_null_[param_index].assign(indicator_size, SQL_NULL_DATA);
 
@@ -1671,14 +1686,14 @@ public:
             SQLBindParameter,
             rc,
             stmt_,               // handle
-            param.index_ + 1,   // parameter number
-            param.iotype_,      // input or output type
-            sql_ctype<T>::value,// value type
-            param.type_,        // parameter type
-            param.size_,        // column size ignored for many types, but needed for strings
-            param.scale_,       // decimal digits
+            param.index_ + 1,    // parameter number
+            param.iotype_,       // input or output type
+            sql_ctype<T>::value, // value type
+            param.type_,         // parameter type
+            param.size_,         // column size ignored for many types, but needed for strings
+            param.scale_,        // decimal digits
             (SQLPOINTER)buffer.values_, // parameter value
-            buffer_size,        // buffer length
+            buffer_size,                // buffer length
             bind_len_or_null_[param.index_].data());
 
         if (!success(rc))
@@ -1690,7 +1705,7 @@ public:
         param_direction direction,
         short param_index,
         T const* values,
-        std::size_t elements,
+        std::size_t batch_size,
         bool const* nulls = nullptr,
         T const* null_sentry = nullptr);
 
@@ -1698,8 +1713,8 @@ public:
         param_direction direction,
         short param_index,
         string_type::value_type const* values,
-        std::size_t length,
-        std::size_t elements,
+        std::size_t value_size,
+        std::size_t batch_size,
         bool const* nulls = nullptr,
         string_type::value_type const* null_sentry = nullptr);
 
@@ -1711,24 +1726,24 @@ public:
         string_type::value_type const* null_sentry = nullptr);
 
     // handles multiple null values
-    void bind_null(short param_index, std::size_t elements)
+    void bind_null(short param_index, std::size_t batch_size)
     {
         bound_parameter param;
-        prepare_bind(param_index, elements, PARAM_IN, param);
+        prepare_bind(param_index, batch_size, PARAM_IN, param);
 
         RETCODE rc;
         NANODBC_CALL_RC(
             SQLBindParameter,
             rc,
             stmt_,
-            param.index_ + 1,   // parameter number
-            param.iotype_,      // input or output typ,
+            param.index_ + 1, // parameter number
+            param.iotype_,    // input or output typ,
             SQL_C_CHAR,
-            param.type_,        // parameter type
-            param.size_,        // column size ignored for many types, but needed for string,
-            0,                  // decimal digits
-            nullptr,            // null value
-            0,                  // buffe length
+            param.type_, // parameter type
+            param.size_, // column size ignored for many types, but needed for string,
+            0,           // decimal digits
+            nullptr,     // null value
+            0,           // buffe length
             bind_len_or_null_[param.index_].data());
         if (!success(rc))
             NANODBC_THROW_DATABASE_ERROR(stmt_, SQL_HANDLE_STMT);
@@ -1759,7 +1774,9 @@ private:
 // Supports code like: query.bind(0, std_string.c_str())
 // In this case, we need to pass nullptr to the final parameter of SQLBindParameter().
 template <>
-void statement::statement_impl::bind_parameter<string_type::value_type>(bound_parameter const& param, bound_buffer<string_type::value_type>& buffer)
+void statement::statement_impl::bind_parameter<string_type::value_type>(
+    bound_parameter const& param,
+    bound_buffer<string_type::value_type>& buffer)
 {
     auto const buffer_size = buffer.value_size_ > 0 ? buffer.value_size_ : param.size_;
 
@@ -1768,14 +1785,14 @@ void statement::statement_impl::bind_parameter<string_type::value_type>(bound_pa
         SQLBindParameter,
         rc,
         stmt_,                                     // handle
-        param.index_ + 1,   // parameter number
-        param.iotype_,      // input or output type
+        param.index_ + 1,                          // parameter number
+        param.iotype_,                             // input or output type
         sql_ctype<string_type::value_type>::value, // value type
-        param.type_,        // parameter type
-        param.size_,        // column size ignored for many types, but needed for strings
-        param.scale_,       // decimal digits
+        param.type_,                               // parameter type
+        param.size_,                // column size ignored for many types, but needed for strings
+        param.scale_,               // decimal digits
         (SQLPOINTER)buffer.values_, // parameter value
-        buffer_size,        // buffer length
+        buffer_size,                // buffer length
         (buffer.size_ <= 1 ? nullptr : bind_len_or_null_[param.index_].data()));
 
     if (!success(rc))
@@ -1787,26 +1804,26 @@ void statement::statement_impl::bind(
     param_direction direction,
     short param_index,
     T const* values,
-    std::size_t elements,
+    std::size_t batch_size,
     bool const* nulls /*= nullptr*/,
     T const* null_sentry /*= nullptr*/)
 {
     bound_parameter param;
-    prepare_bind(param_index, elements, direction, param);
+    prepare_bind(param_index, batch_size, direction, param);
 
     if (nulls || null_sentry)
     {
-        for (std::size_t i = 0; i < elements; ++i)
+        for (std::size_t i = 0; i < batch_size; ++i)
             if ((null_sentry && !equals(values[i], *null_sentry)) || (nulls && !nulls[i]) || !nulls)
                 bind_len_or_null_[param_index][i] = param.size_;
     }
     else
     {
-        for (std::size_t i = 0; i < elements; ++i)
+        for (std::size_t i = 0; i < batch_size; ++i)
             bind_len_or_null_[param_index][i] = param.size_;
     }
 
-    bound_buffer<T> buffer(values, elements);
+    bound_buffer<T> buffer(values, batch_size);
     bind_parameter(param, buffer);
 }
 
@@ -1818,43 +1835,53 @@ void statement::statement_impl::bind_strings(
     string_type::value_type const* null_sentry /*= nullptr*/)
 {
 
-    size_t const elements = values.size();
+    size_t const batch_size = values.size();
     bound_parameter param;
-    prepare_bind(param_index, elements, direction, param);
+    prepare_bind(param_index, batch_size, direction, param);
 
     size_t max_length = 0;
-    for (std::size_t i = 0; i < elements; ++i)
+    for (std::size_t i = 0; i < batch_size; ++i)
     {
         max_length = std::max(values[i].length(), max_length);
     }
     // add space for null terminator
     ++max_length;
 
-    string_data_[param_index] = std::vector<string_type::value_type>(elements * max_length, 0);
-    for (std::size_t i = 0; i < elements; ++i)
+    string_data_[param_index] = std::vector<string_type::value_type>(batch_size * max_length, 0);
+    for (std::size_t i = 0; i < batch_size; ++i)
     {
-        std::copy(values[i].begin(), values[i].end(), string_data_[param_index].data() + (i * max_length));
+        std::copy(
+            values[i].begin(),
+            values[i].end(),
+            string_data_[param_index].data() + (i * max_length));
     }
-    bind_strings(direction, param_index, string_data_[param_index].data(), max_length, elements, nulls, null_sentry);
+    bind_strings(
+        direction,
+        param_index,
+        string_data_[param_index].data(),
+        max_length,
+        batch_size,
+        nulls,
+        null_sentry);
 }
 
 void statement::statement_impl::bind_strings(
     param_direction direction,
     short param_index,
     string_type::value_type const* values,
-    std::size_t length,
-    std::size_t elements,
+    std::size_t value_size,
+    std::size_t batch_size,
     bool const* nulls /*= nullptr*/,
     string_type::value_type const* null_sentry /*= nullptr*/)
 {
     bound_parameter param;
-    prepare_bind(param_index, elements, direction, param);
+    prepare_bind(param_index, batch_size, direction, param);
 
     if (null_sentry)
     {
-        for (std::size_t i = 0; i < elements; ++i)
+        for (std::size_t i = 0; i < batch_size; ++i)
         {
-            const string_type s_lhs(values + i * length, values + (i + 1) * length);
+            const string_type s_lhs(values + i * value_size, values + (i + 1) * value_size);
             const string_type s_rhs(null_sentry);
 #if NANODBC_USE_UNICODE
             std::string narrow_lhs;
@@ -1863,17 +1890,17 @@ void statement::statement_impl::bind_strings(
             std::string narrow_rhs;
             narrow_rhs.reserve(s_rhs.size());
             convert(s_rhs, narrow_rhs);
-            if (std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length) != 0)
-              bind_len_or_null_[param_index][i] = SQL_NTS;
+            if (std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), value_size) != 0)
+                bind_len_or_null_[param_index][i] = SQL_NTS;
 #else
-            if (std::strncmp(s_lhs.c_str(), s_rhs.c_str(), length) != 0)
-              bind_len_or_null_[param_index][i] = SQL_NTS;
+            if (std::strncmp(s_lhs.c_str(), s_rhs.c_str(), value_size) != 0)
+                bind_len_or_null_[param_index][i] = SQL_NTS;
 #endif
         }
     }
     else if (nulls)
     {
-        for (std::size_t i = 0; i < elements; ++i)
+        for (std::size_t i = 0; i < batch_size; ++i)
         {
             if (!nulls[i])
                 bind_len_or_null_[param_index][i] = SQL_NTS; // null terminated
@@ -1881,14 +1908,14 @@ void statement::statement_impl::bind_strings(
     }
     else
     {
-        for (std::size_t i = 0; i < elements; ++i)
+        for (std::size_t i = 0; i < batch_size; ++i)
         {
             bind_len_or_null_[param_index][i] = SQL_NTS;
         }
     }
 
-    auto const buffer_length = length * sizeof(string_type::value_type);
-    bound_buffer<string_type::value_type> buffer(values, elements, buffer_length);
+    auto const buffer_length = value_size * sizeof(string_type::value_type);
+    bound_buffer<string_type::value_type> buffer(values, batch_size, buffer_length);
     bind_parameter(param, buffer);
 }
 
@@ -3596,7 +3623,7 @@ unsigned long statement::parameter_size(short param) const
     template void statement::bind(                                                                 \
         short, const type*, std::size_t, const type*, param_direction); /* n-ary, sentry */        \
     template void statement::bind(                                                                 \
-        short, const type*, std::size_t, const bool*, param_direction) /* n-ary, flags */ /**/
+        short, const type*, std::size_t, const bool*, param_direction) /* n-ary, flags */
 
 // The following are the only supported instantiations of statement::bind().
 NANODBC_INSTANTIATE_BINDS(string_type::value_type);
@@ -3621,95 +3648,98 @@ void statement::bind(short param_index, const T* value, param_direction directio
 }
 
 template <class T>
-void statement::bind(short param_index, const T* values, std::size_t elements, param_direction direction)
+void statement::bind(
+    short param_index,
+    T const* values,
+    std::size_t batch_size,
+    param_direction direction)
 {
-    impl_->bind(direction, param_index, values, elements);
+    impl_->bind(direction, param_index, values, batch_size);
 }
 
 template <class T>
 void statement::bind(
     short param_index,
-    const T* values,
-    std::size_t elements,
-    const T* null_sentry,
+    T const* values,
+    std::size_t batch_size,
+    T const* null_sentry,
     param_direction direction)
 {
-    impl_->bind(direction, param_index, values, elements, nullptr, null_sentry);
+    impl_->bind(direction, param_index, values, batch_size, nullptr, null_sentry);
 }
 
 template <class T>
 void statement::bind(
     short param_index,
-    const T* values,
-    std::size_t elements,
-    const bool* nulls,
+    T const* values,
+    std::size_t batch_size,
+    bool const* nulls,
     param_direction direction)
 {
-    impl_->bind(direction, param_index, values, elements, nulls, (T*)0);
+    impl_->bind(direction, param_index, values, batch_size, nulls, (T*)0);
 }
 
 void statement::bind_strings(
     short param_index,
-    const std::vector<string_type>& values,
+    std::vector<string_type> const& values,
     param_direction direction)
 {
-
     impl_->bind_strings(direction, param_index, values, nullptr, nullptr);
 }
 
 void statement::bind_strings(
-    short param,
-    const string_type::value_type* values,
-    std::size_t length,
-    std::size_t elements,
+    short param_index,
+    string_type::value_type const* values,
+    std::size_t value_size,
+    std::size_t batch_size,
     param_direction direction)
 {
-    impl_->bind_strings(direction, param, values, length, elements);
+    impl_->bind_strings(direction, param_index, values, value_size, batch_size);
 }
 
 void statement::bind_strings(
-    short param,
-    const string_type::value_type* values,
-    std::size_t length,
-    std::size_t elements,
-    const string_type::value_type* null_sentry,
+    short param_index,
+    string_type::value_type const* values,
+    std::size_t value_size,
+    std::size_t batch_size,
+    string_type::value_type const* null_sentry,
     param_direction direction)
 {
-    impl_->bind_strings(direction, param, values, length, elements, nullptr, null_sentry);
+    impl_->bind_strings(direction, param_index, values, value_size, batch_size, nullptr, null_sentry);
 }
 
 void statement::bind_strings(
-    short param,
-    const string_type::value_type* values,
-    std::size_t length,
-    std::size_t elements,
-    const bool* nulls,
+    short param_index,
+    string_type::value_type const* values,
+    std::size_t value_size,
+    std::size_t batch_size,
+    bool const* nulls,
     param_direction direction)
 {
-    impl_->bind_strings(direction, param, values, length, elements, nulls);
+    impl_->bind_strings(direction, param_index, values, value_size, batch_size, nulls);
 }
 
 void statement::bind_strings(
-    short param,
-    const std::vector<string_type>& values,
-    const string_type::value_type* null_sentry,
+    short param_index,
+    std::vector<string_type> const& values,
+    string_type::value_type const* null_sentry,
     param_direction direction)
 {
-    impl_->bind_strings(direction, param, values, nullptr, null_sentry);
+    impl_->bind_strings(direction, param_index, values, nullptr, null_sentry);
 }
 
 void statement::bind_strings(
-    short param,
-    const std::vector<string_type>& values,
-    const bool* nulls,
+    short param_index,
+    std::vector<string_type> const& values,
+    bool const* nulls,
     param_direction direction)
 {
-    impl_->bind_strings(direction, param, values, nulls, nullptr);
+    impl_->bind_strings(direction, param_index, values, nulls, nullptr);
 }
 
-void statement::bind_null(short param, std::size_t elements)
+void statement::bind_null(short param_index, std::size_t batch_size)
 {
-    impl_->bind_null(param, elements);
+    impl_->bind_null(param_index, batch_size);
 }
 
 } // namespace nanodbc

--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -1852,10 +1852,9 @@ void statement::statement_impl::bind_strings(
 
     if (null_sentry)
     {
-        auto const char_size = sizeof(string_type::value_type);
         for (std::size_t i = 0; i < elements; ++i)
         {
-            const string_type s_lhs(values + i * length / char_size, values + (i + 1) * length / char_size);
+            const string_type s_lhs(values + i * length, values + (i + 1) * length);
             const string_type s_rhs(null_sentry);
 #if NANODBC_USE_UNICODE
             std::string narrow_lhs;
@@ -1864,7 +1863,7 @@ void statement::statement_impl::bind_strings(
             std::string narrow_rhs;
             narrow_rhs.reserve(s_rhs.size());
             convert(s_rhs, narrow_rhs);
-            if (std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length / char_size) != 0)
+            if (std::strncmp(narrow_lhs.c_str(), narrow_rhs.c_str(), length) != 0)
               bind_len_or_null_[param_index][i] = SQL_NTS;
 #else
             if (std::strncmp(s_lhs.c_str(), s_rhs.c_str(), length) != 0)

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -699,12 +699,12 @@ public:
     /// It is NOT possible to use these functions for batch operations as number of elements is not
     /// specified here.
     ///
-    /// \param param Placeholder position.
+    /// \param param_index Zero-based index of parameter marker (placeholder position).
     /// \param value Value to substitute into placeholder.
     /// \param direction ODBC parameter direction.
     /// \throws database_error
     template <class T>
-    void bind(short param, const T* value, param_direction direction = PARAM_IN);
+    void bind(short param_index, const T* value, param_direction direction = PARAM_IN);
 
     /// \addtogroup bind_multi Binding multiple non-string values
     /// \brief Binds given values to given parameter placeholder number in the prepared statement.
@@ -714,7 +714,7 @@ public:
     ///
     /// It is possible to use these functions for batch operations.
     ///
-    /// \param param Placeholder position.
+    /// \param param_index Zero-based index of parameter marker (placeholder position).
     /// \param values Values to substitute into placeholder.
     /// \param elements The number of elements being bound.
     /// \param null_sentry Value which should represent a null value.
@@ -728,13 +728,13 @@ public:
     /// \see bind_multi
     template <class T>
     void
-    bind(short param, const T* values, std::size_t elements, param_direction direction = PARAM_IN);
+    bind(short param_index, const T* values, std::size_t elements, param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple values.
     /// \see bind_multi
     template <class T>
     void bind(
-        short param,
+        short param_index,
         const T* values,
         std::size_t elements,
         const T* null_sentry,
@@ -744,7 +744,7 @@ public:
     /// \see bind_multi
     template <class T>
     void bind(
-        short param,
+        short param_index,
         const T* values,
         std::size_t elements,
         const bool* nulls,
@@ -774,7 +774,7 @@ public:
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type* values,
         std::size_t length,
         std::size_t elements,
@@ -783,7 +783,7 @@ public:
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const std::vector<string_type>& values,
         param_direction direction = PARAM_IN);
 
@@ -791,18 +791,18 @@ public:
     /// \see bind_strings
     template <std::size_t N, std::size_t M>
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type (&values)[N][M],
         param_direction direction = PARAM_IN)
     {
-        bind_strings(
-            param, reinterpret_cast<const string_type::value_type*>(values), M, N, direction);
+        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        bind_strings(param_index, param_values, M, N, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type* values,
         std::size_t length,
         std::size_t elements,
@@ -812,7 +812,7 @@ public:
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const std::vector<string_type>& values,
         const string_type::value_type* null_sentry,
         param_direction direction = PARAM_IN);
@@ -821,24 +821,19 @@ public:
     /// \see bind_strings
     template <std::size_t N, std::size_t M>
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type (&values)[N][M],
         const string_type::value_type* null_sentry,
         param_direction direction = PARAM_IN)
     {
-        bind_strings(
-            param,
-            reinterpret_cast<const string_type::value_type*>(values),
-            M,
-            N,
-            null_sentry,
-            direction);
+        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        bind_strings(param_index, param_values, M, N, null_sentry, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type* values,
         std::size_t length,
         std::size_t elements,
@@ -848,7 +843,7 @@ public:
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
-        short param,
+        short param_index,
         const std::vector<string_type>& values,
         const bool* nulls,
         param_direction direction = PARAM_IN);
@@ -857,18 +852,13 @@ public:
     /// \see bind_strings
     template <std::size_t N, std::size_t M>
     void bind_strings(
-        short param,
+        short param_index,
         const string_type::value_type (&values)[N][M],
         const bool* nulls,
         param_direction direction = PARAM_IN)
     {
-        bind_strings(
-            param,
-            reinterpret_cast<const string_type::value_type*>(values),
-            M,
-            N,
-            nulls,
-            direction);
+        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        bind_strings(param_index, param_values, M, N, nulls, direction);
     }
 
     /// @}
@@ -883,7 +873,7 @@ public:
     /// \param param Placeholder position.
     /// \param elements The number of elements being bound.
     /// \throws database_error
-    void bind_null(short param, std::size_t elements = 1);
+    void bind_null(short param_index, std::size_t elements = 1);
 
     /// @}
 

--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -684,7 +684,7 @@ public:
     void reset_parameters() NANODBC_NOEXCEPT;
 
     /// \brief Returns parameter size for indicated parameter placeholder in a prepared statement.
-    unsigned long parameter_size(short param) const;
+    unsigned long parameter_size(short param_index) const;
 
     /// \addtogroup binding Binding parameters
     /// \brief These functions are used to bind values to ODBC parameters.
@@ -704,19 +704,20 @@ public:
     /// \param direction ODBC parameter direction.
     /// \throws database_error
     template <class T>
-    void bind(short param_index, const T* value, param_direction direction = PARAM_IN);
+    void bind(short param_index, T const* value, param_direction direction = PARAM_IN);
 
     /// \addtogroup bind_multi Binding multiple non-string values
     /// \brief Binds given values to given parameter placeholder number in the prepared statement.
     ///
-    /// If your prepared SQL query has any ? placeholders, this is how you bind values to them.
-    /// Placeholder numbers count from left to right and are 0-indexed.
+    /// If your prepared SQL query has any parameter markers, ? (question  mark) placeholders,
+    /// this is how you bind values to them.
+    /// Parameter markers are numbered using Zero-based index from left to right.
     ///
     /// It is possible to use these functions for batch operations.
     ///
     /// \param param_index Zero-based index of parameter marker (placeholder position).
     /// \param values Values to substitute into placeholder.
-    /// \param elements The number of elements being bound.
+    /// \param batch_size The number of values being bound.
     /// \param null_sentry Value which should represent a null value.
     /// \param nulls Flags for values that should be set to a null value.
     /// \param param_direciton ODBC parameter direction.
@@ -727,17 +728,10 @@ public:
     /// \brief Binds multiple values.
     /// \see bind_multi
     template <class T>
-    void
-    bind(short param_index, const T* values, std::size_t elements, param_direction direction = PARAM_IN);
-
-    /// \brief Binds multiple values.
-    /// \see bind_multi
-    template <class T>
     void bind(
         short param_index,
-        const T* values,
-        std::size_t elements,
-        const T* null_sentry,
+        T const* values,
+        std::size_t batch_size,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple values.
@@ -745,25 +739,37 @@ public:
     template <class T>
     void bind(
         short param_index,
-        const T* values,
-        std::size_t elements,
-        const bool* nulls,
+        T const* values,
+        std::size_t batch_size,
+        T const* null_sentry,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds multiple values.
+    /// \see bind_multi
+    template <class T>
+    void bind(
+        short param_index,
+        T const* values,
+        std::size_t batch_size,
+        bool const* nulls,
         param_direction direction = PARAM_IN);
 
     /// @}
 
     /// \addtogroup bind_strings Binding multiple string values
-    /// \brief Binds given string values to parameter placeholder number in prepared statement.
+    /// \brief Binds given string values to parameter marker in prepared statement.
     ///
-    /// If your prepared SQL query has any ? placeholders, this is how you bind values to them.
-    /// Placeholder numbers count from left to right and are 0-indexed.
+    /// If your prepared SQL query has any parameter markers, ? (question  mark) placeholders,
+    /// this is how you bind values to them.
+    /// Parameter markers are numbered using Zero-based index from left to right.
     ///
     /// It is possible to use these functions for batch operations.
     ///
-    /// \param param Placeholder position.
-    /// \param values Values to substitute into placeholder.
-    /// \param length Maximum length of string elements.
-    /// \param elements Number of elements to bind. Otherwise N is taken as the number of elements.
+    /// \param param_index Zero-based index of parameter marker (placeholder position).
+    /// \param values Array of values to substitute into parameter placeholders.
+    /// \param value_size Maximum length of string value in array.
+    /// \param batch_size Number of string values to bind. Otherwise template parameter BatchSize is
+    /// taken as the number of values.
     /// \param null_sentry Value which should represent a null value.
     /// \param nulls Flags for values that should be set to a null value.
     /// \param param_direciton ODBC parameter direction.
@@ -775,105 +781,110 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        const string_type::value_type* values,
-        std::size_t length,
-        std::size_t elements,
+        string_type::value_type const* values,
+        std::size_t value_size,
+        std::size_t batch_size,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds multiple string values.
+    ///
+    /// Size of the values vector indicates number of values to bind.
+    /// Longest string in the array determines maximum length of individual value.
+    ///
+    /// \see bind_strings
+    void bind_strings(
+        short param_index,
+        std::vector<string_type> const& values,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        const std::vector<string_type>& values,
-        param_direction direction = PARAM_IN);
-
-    /// \brief Binds multiple string values.
-    /// \see bind_strings
-    template <std::size_t N, std::size_t M>
-    void bind_strings(
-        short param_index,
-        const string_type::value_type (&values)[N][M],
+        string_type::value_type const (&values)[BatchSize][ValueSize],
         param_direction direction = PARAM_IN)
     {
         auto param_values = reinterpret_cast<string_type::value_type const*>(values);
-        bind_strings(param_index, param_values, M, N, direction);
+        bind_strings(param_index, param_values, ValueSize, BatchSize, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        const string_type::value_type* values,
-        std::size_t length,
-        std::size_t elements,
-        const string_type::value_type* null_sentry,
+        string_type::value_type const* values,
+        std::size_t value_size,
+        std::size_t batch_size,
+        string_type::value_type const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        const std::vector<string_type>& values,
-        const string_type::value_type* null_sentry,
+        std::vector<string_type> const& values,
+        string_type::value_type const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
-    template <std::size_t N, std::size_t M>
+    template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        const string_type::value_type (&values)[N][M],
-        const string_type::value_type* null_sentry,
+        string_type::value_type const (&values)[BatchSize][ValueSize],
+        string_type::value_type const* null_sentry,
         param_direction direction = PARAM_IN)
     {
         auto param_values = reinterpret_cast<string_type::value_type const*>(values);
-        bind_strings(param_index, param_values, M, N, null_sentry, direction);
+        bind_strings(param_index, param_values, ValueSize, BatchSize, null_sentry, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        const string_type::value_type* values,
-        std::size_t length,
-        std::size_t elements,
-        const bool* nulls,
+        string_type::value_type const* values,
+        std::size_t value_size,
+        std::size_t batch_size,
+        bool const* nulls,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        const std::vector<string_type>& values,
-        const bool* nulls,
+        std::vector<string_type> const& values,
+        bool const* nulls,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
-    template <std::size_t N, std::size_t M>
+    template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        const string_type::value_type (&values)[N][M],
-        const bool* nulls,
+        string_type::value_type const (&values)[BatchSize][ValueSize],
+        bool const* nulls,
         param_direction direction = PARAM_IN)
     {
         auto param_values = reinterpret_cast<string_type::value_type const*>(values);
-        bind_strings(param_index, param_values, M, N, nulls, direction);
+        bind_strings(param_index, param_values, ValueSize, BatchSize, nulls, direction);
     }
 
     /// @}
 
     /// \brief Binds null values to the parameter placeholder number in the prepared statement.
     ///
-    /// If your prepared SQL query has any ? placeholders, this is how you bind values to them.
-    /// Placeholder numbers count from left to right and are 0-indexed.
+    /// If your prepared SQL query has any parameter markers, ? (question  mark) placeholders,
+    /// this is how you bind values to them.
+    /// Parameter markers are numbered using Zero-based index from left to right.
     ///
     /// It is possible to use this function for batch operations.
     ///
-    /// \param param Placeholder position.
-    /// \param elements The number of elements being bound.
+    /// \param param_index Zero-based index of parameter marker (placeholder position).
+    /// \param batch_size The number of elements being bound.
     /// \throws database_error
-    void bind_null(short param_index, std::size_t elements = 1);
+    void bind_null(short param_index, std::size_t batch_size = 1);
 
     /// @}
 

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -401,6 +401,88 @@ struct base_test_fixture
 
     // Test Cases
 
+    template <std::size_t N, std::size_t M>
+    void batch_insert_string_test_template(nanodbc::connection& conn, const nanodbc::string_type::value_type (&strings)[N][M])
+    {
+        create_table(conn, NANODBC_TEXT("batch_insert_string_test"), NANODBC_TEXT("(s varchar(60))"));
+
+        nanodbc::statement stmt(conn);
+        prepare(stmt, NANODBC_TEXT("insert into batch_insert_string_test(s) values (?);"));
+        stmt.bind_strings(0, strings);
+
+        nanodbc::transact(stmt, N);
+        {
+            auto result = nanodbc::execute(conn, NANODBC_TEXT("select s from batch_insert_string_test"));
+            std::size_t i = 0;
+            while (result.next())
+            {
+                REQUIRE(result.get<nanodbc::string_type>(0) == strings[i]);
+                ++i;
+            }
+        }
+    }
+
+    void batch_insert_string_test()
+    {
+        auto conn = connect();
+
+        // Test input buffer lengths smaller than and equal to column size.
+        std::size_t const strings_size = 5;
+        nanodbc::string_type::value_type strings25[strings_size][25] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings25);
+
+        nanodbc::string_type::value_type strings27[strings_size][27] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings27);
+
+        nanodbc::string_type::value_type strings30[strings_size][30] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings30);
+
+        nanodbc::string_type::value_type strings41[strings_size][41] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings41);
+
+        nanodbc::string_type::value_type strings55[strings_size][55] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings55);
+
+        nanodbc::string_type::value_type strings60[strings_size][60] = {
+            NANODBC_TEXT("first string"),
+            NANODBC_TEXT("second string"),
+            NANODBC_TEXT("third string"),
+            NANODBC_TEXT("this is fourth string"),
+            NANODBC_TEXT("finally, the fifthstring")
+        };
+        batch_insert_string_test_template(conn, strings60);
+    }
+
     void blob_test()
     {
         nanodbc::string_type s = NANODBC_TEXT(

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -87,9 +87,19 @@ TEST_CASE_METHOD(mssql_fixture, "affected_rows_test", "[mssql][affected_rows]")
     }
 }
 
-TEST_CASE_METHOD(mssql_fixture, "batch_insert_string_test", "[mssql][batch]")
+TEST_CASE_METHOD(mssql_fixture, "batch_insert_integral_test", "[mssql][batch][integral]")
+{
+    batch_insert_integral_test();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "batch_insert_string_test", "[mssql][batch][string]")
 {
     batch_insert_string_test();
+}
+
+TEST_CASE_METHOD(mssql_fixture, "batch_insert_mixed_test", "[mssql][batch]")
+{
+    batch_insert_mixed_test();
 }
 
 TEST_CASE_METHOD(mssql_fixture, "blob_test", "[mssql][blob][binary][varbinary]")

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -87,6 +87,11 @@ TEST_CASE_METHOD(mssql_fixture, "affected_rows_test", "[mssql][affected_rows]")
     }
 }
 
+TEST_CASE_METHOD(mssql_fixture, "batch_insert_string_test", "[mssql][batch]")
+{
+    batch_insert_string_test();
+}
+
 TEST_CASE_METHOD(mssql_fixture, "blob_test", "[mssql][blob][binary][varbinary]")
 {
     nanodbc::connection connection = connect();

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -69,6 +69,21 @@ TEST_CASE_METHOD(mysql_fixture, "affected_rows_test", "[mysql][affected_rows]")
     }
 }
 
+TEST_CASE_METHOD(mysql_fixture, "batch_insert_integer_test", "[mysql][batch][integral]")
+{
+    batch_insert_integral_test();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "batch_insert_string_test", "[mysql][batch][string]")
+{
+    batch_insert_string_test();
+}
+
+TEST_CASE_METHOD(mysql_fixture, "batch_insert_mixed_test", "[mysql][batch]")
+{
+    batch_insert_mixed_test();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "blob_test", "[mysql][blob]")
 {
     blob_test();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -27,6 +27,21 @@ TEST_CASE_METHOD(postgresql_fixture, "driver_test", "[postgresql][driver]")
     driver_test();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "batch_insert_integer_test", "[postgresql][batch][integral]")
+{
+    batch_insert_integral_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "batch_insert_string_test", "[postgresql][batch][string]")
+{
+    batch_insert_string_test();
+}
+
+TEST_CASE_METHOD(postgresql_fixture, "batch_insert_mixed_test", "[postgresql][batch]")
+{
+    batch_insert_mixed_test();
+}
+
 TEST_CASE_METHOD(
     postgresql_fixture,
     "catalog_list_catalogs_test",
@@ -134,7 +149,8 @@ TEST_CASE_METHOD(postgresql_fixture, "string_test", "[postgresql][string]")
     string_test();
 }
 
-TEST_CASE_METHOD(postgresql_fixture, "string_vector_test", "[postgresql][string]") {
+TEST_CASE_METHOD(postgresql_fixture, "string_vector_test", "[postgresql][string]")
+{
     string_vector_test();
 }
 

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -100,19 +100,23 @@ TEST_CASE_METHOD(sqlite_fixture, "driver_test", "[sqlite][driver]")
     driver_test();
 }
 
+// TODO: Investigate why these tests fail on Linux
+// See https://github.com/lexicalunit/nanodbc/pull/220#issuecomment-257029475
+#ifdef _WIN32
 TEST_CASE_METHOD(sqlite_fixture, "batch_insert_integral_test", "[sqlite][batch][integral]")
 {
     batch_insert_integral_test();
 }
 
-TEST_CASE_METHOD(sqlite_fixture, "batch_insert_string_test", "[sqlite][batch][string]")
-{
-    batch_insert_string_test();
-}
-
 TEST_CASE_METHOD(sqlite_fixture, "batch_insert_mixed_test", "[sqlite][batch]")
 {
     batch_insert_mixed_test();
+}
+#endif // _WIN32
+
+TEST_CASE_METHOD(sqlite_fixture, "batch_insert_string_test", "[sqlite][batch][string]")
+{
+    batch_insert_string_test();
 }
 
 TEST_CASE_METHOD(sqlite_fixture, "blob_test", "[sqlite][blob]")

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -100,6 +100,11 @@ TEST_CASE_METHOD(sqlite_fixture, "driver_test", "[sqlite][driver]")
     driver_test();
 }
 
+TEST_CASE_METHOD(sqlite_fixture, "batch_insert_string_test", "[sqlite][batch]")
+{
+    batch_insert_string_test();
+}
+
 TEST_CASE_METHOD(sqlite_fixture, "blob_test", "[sqlite][blob]")
 {
     blob_test();

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -100,9 +100,19 @@ TEST_CASE_METHOD(sqlite_fixture, "driver_test", "[sqlite][driver]")
     driver_test();
 }
 
-TEST_CASE_METHOD(sqlite_fixture, "batch_insert_string_test", "[sqlite][batch]")
+TEST_CASE_METHOD(sqlite_fixture, "batch_insert_integral_test", "[sqlite][batch][integral]")
+{
+    batch_insert_integral_test();
+}
+
+TEST_CASE_METHOD(sqlite_fixture, "batch_insert_string_test", "[sqlite][batch][string]")
 {
     batch_insert_string_test();
+}
+
+TEST_CASE_METHOD(sqlite_fixture, "batch_insert_mixed_test", "[sqlite][batch]")
+{
+    batch_insert_mixed_test();
 }
 
 TEST_CASE_METHOD(sqlite_fixture, "blob_test", "[sqlite][blob]")

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -27,6 +27,21 @@ TEST_CASE_METHOD(vertica_fixture, "driver_test", "[vertica][driver]")
     driver_test();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "batch_insert_integer_test", "[vertica][batch][integral]")
+{
+    batch_insert_integral_test();
+}
+
+TEST_CASE_METHOD(vertica_fixture, "batch_insert_string_test", "[vertica][batch][string]")
+{
+    batch_insert_string_test();
+}
+
+TEST_CASE_METHOD(vertica_fixture, "batch_insert_mixed_test", "[vertica][batch]")
+{
+    batch_insert_mixed_test();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "catalog_list_catalogs_test", "[vertica][catalog][catalogs]")
 {
     catalog_list_catalogs_test();


### PR DESCRIPTION
Proposal of `bind` functions refactoring including fix for known bug in binding batch of strings (#116).
This PR also attempts to start the [Roadmap](https://github.com/lexicalunit/nanodbc#future-work) item on _cleaning up the `bind_*` family of functions, reduce any duplication_.

Looking for review, especially from @lexicalunit and @jimhester whose work might be directly affected by this PR.

-------
Fix incorrect size passed to `SQLBindParameter` while inserting batch of strings (#116).
Add test for batch insertion of strings using variety of lenghts of input string data.

Bundle numerous parameters of bind functions in `bound_parameter` and `bound_buffer` objects.
Clarify which type, size, etc. refer to which element of bound parameter:
parameter marker/column or actual data value, SQL size or C size, etc.
Clarify size of values container (ie. array) vs size of value element (ie. array item).

Remove superfluous bind overloads.
