### PR TITLE
Enable running time_test against MySQL, PgSQL, Vertica

### DIFF
--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -224,6 +224,11 @@ TEST_CASE_METHOD(mysql_fixture, "test_batch_binary", "[mysql][binary]")
     test_batch_binary();
 }
 
+TEST_CASE_METHOD(mysql_fixture, "test_time", "[mysql][time]")
+{
+    test_time();
+}
+
 TEST_CASE_METHOD(mysql_fixture, "test_transaction", "[mysql][transaction]")
 {
     test_transaction();

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -157,6 +157,11 @@ TEST_CASE_METHOD(postgresql_fixture, "test_batch_binary", "[postgresql][binary]"
     test_batch_binary();
 }
 
+TEST_CASE_METHOD(postgresql_fixture, "test_time", "[postgresql][time]")
+{
+    test_time();
+}
+
 TEST_CASE_METHOD(postgresql_fixture, "test_transaction", "[postgresql][transaction]")
 {
     test_transaction();

--- a/test/vertica_test.cpp
+++ b/test/vertica_test.cpp
@@ -133,6 +133,11 @@ TEST_CASE_METHOD(vertica_fixture, "test_string_vector", "[vertica][string]")
     test_string_vector();
 }
 
+TEST_CASE_METHOD(vertica_fixture, "test_time", "[vertica][time]")
+{
+    test_time();
+}
+
 TEST_CASE_METHOD(vertica_fixture, "test_transaction", "[vertica][transaction]")
 {
     test_transaction();


### PR DESCRIPTION
The test can not be enabled for SQL Server due to ODBC type issues (see #226).