### PR TITLE
Add very minimal support for SQL Server-specific time datatypes

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -55,6 +55,26 @@
 #include <sql.h>
 #include <sqlext.h>
 
+// Driver specific SQL data type defines.
+// Microsoft has -150 thru -199 reserved for Microsoft SQL Server Native Client driver usage.
+// Originally, defined in sqlncli.h (old SQL Server Native Client driver)
+// and msodbcsql.h (new Microsoft ODBC Driver for SQL Server)
+// See https://github.com/lexicalunit/nanodbc/issues/226
+#ifndef SQL_SS_VARIANT
+#define SQL_SS_VARIANT (-150)
+#endif
+#ifndef SQL_SS_XML
+#define SQL_SS_XML (-152)
+#endif
+#ifndef SQL_SS_TABLE
+#define SQL_SS_TABLE (-153)
+#endif
+#ifndef SQL_SS_TIME2
+#define SQL_SS_TIME2 (-154)
+#endif
+#ifndef SQL_SS_TIMESTAMPOFFSET
+#define SQL_SS_TIMESTAMPOFFSET (-155)
+#endif
 // Large CLR User-Defined Types (ODBC)
 // https://msdn.microsoft.com/en-us/library/bb677316.aspx
 // Essentially, UDT is a varbinary type with additional metadata.
@@ -2545,11 +2565,13 @@ private:
                 break;
             case SQL_TIME:
             case SQL_TYPE_TIME:
+            case SQL_SS_TIME2:
                 col.ctype_ = SQL_C_TIME;
                 col.clen_ = sizeof(time);
                 break;
             case SQL_TIMESTAMP:
             case SQL_TYPE_TIMESTAMP:
+            case SQL_SS_TIMESTAMPOFFSET:
                 col.ctype_ = SQL_C_TIMESTAMP;
                 col.clen_ = sizeof(timestamp);
                 break;


### PR DESCRIPTION
Handle the new time types introduced in SQL Server 2008 and
SQL Server Native Client (SNAC), but still supported in SQL Server 2016
and Microsoft ODBC Driver for SQL Server.

Define SQL Server-specific constants based on sqlncli.h and msodbcsql.h.
Bind `SQL_SS_TIME2` as `SQL_C_TIME`.
Bind `SQL_SS_TIMESTAMPOFFSET` as `SQL_C_TIMESTAMP`.

See Issues #224 and  #226 for detailed discussion.

Note, currently, nanodbc binds `SQL_SS_TIMESTAMPOFFSET` as `SQL_C_TIMESTAMP`, not as `SQL_C_SS_TIMESTAMPOFFSET`.
This seems to cause the DBMS or the driver to convert the time to local time based on time zone.
See `mssql_test.cpp/test_datetimeoffset` for details.

For example, `2006-12-31T13:45:12.345-08:00` (PST) value inserted into `DATETIMEOFFSET` (datetime with time zone), bound as `SQL_C_TIMESTAMP`, will be fetched as `2006-12-31T22:45:12.345` where the hour is shifted to 21 GMT or 22 CET, depending on the client local time zone.