### PR TITLE
Add result::column_datatype_name method

### DIFF
--- a/src/nanodbc.h
+++ b/src/nanodbc.h
@@ -1358,6 +1358,24 @@ public:
     /// \brief Returns a identifying integer value representing the SQL type of this column by name.
     int column_datatype(const string_type& column_name) const;
 
+    /// \brief Returns data source–dependent data type name of this column.
+    ///
+    /// The function calls SQLCoLAttribute with the field attribute SQL_DESC_TYPE_NAME to
+    /// obtain the data type name.
+    /// If the type is unknown, an empty string is returned.
+    /// \note Unlike other column metadata functions (eg. column_datatype()),
+    /// this function cost is an extra ODBC API call.
+    string_type column_datatype_name(short column) const;
+
+    /// \brief Returns data source–dependent data type name of this column by name.
+    ///
+    /// The function calls SQLCoLAttribute with the field attribute SQL_DESC_TYPE_NAME to
+    /// obtain the data type name.
+    /// If the type is unknown, an empty string is returned.
+    /// \note Unlike other column metadata functions (eg. column_datatype()),
+    /// this function cost is an extra ODBC API call.
+    string_type column_datatype_name(const string_type& column_name) const;
+
     /// \brief Returns a identifying integer value representing the C type of this column.
     int column_c_datatype(short column) const;
 

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -745,9 +745,14 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(result.column_name(0) == NANODBC_TEXT("i"));
         REQUIRE(result.column_datatype(0) == SQL_INTEGER);
         if (vendor_ == database_vendor::sqlserver)
+        {
             REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
+        }
         else if (vendor_ == database_vendor::sqlite)
+        {
+            REQUIRE(result.column_datatype_name(0) == NANODBC_TEXT("int"));
             REQUIRE(result.column_c_datatype(0) == SQL_C_SBIGINT);
+        }
         REQUIRE(result.column_size(0) == 10);
         REQUIRE(result.column_decimal_digits(0) == 0);
         // d decimal(7,3)
@@ -755,6 +760,7 @@ struct test_case_fixture : public base_test_fixture
         if (vendor_ == database_vendor::sqlite)
         {
 #ifdef _WIN32
+            REQUIRE(result.column_datatype_name(1) == NANODBC_TEXT("decimal"));
             REQUIRE(result.column_datatype(1) == -9);   // FIXME: What is this type?
             REQUIRE(result.column_c_datatype(1) == -8); // FIXME: What is this type
             REQUIRE(result.column_size(1) == 7); // FIXME: SQLite ODBC mis-reports decimal digits?
@@ -780,6 +786,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(result.column_size(2) == 7);
         if (vendor_ == database_vendor::sqlite)
         {
+            REQUIRE(result.column_datatype_name(2) == NANODBC_TEXT("numeric"));
             REQUIRE(result.column_datatype(2) == 8); // FIXME: What is this type?
             // FIXME: SQLite ODBC mis-reports decimal digits?
             REQUIRE(result.column_decimal_digits(2) == 0);


### PR DESCRIPTION
Calls [SQLColAttribute](https://msdn.microsoft.com/en-us/library/ms713558(v=vs.85).aspx) with the field attribute `SQL_DESC_TYPE_NAME` to obtain the data type name.

The function is complementary to `columns::type_name()`, but invokable on query result to, so it is not necessary to open new [SQLColumns](https://msdn.microsoft.com/en-us/library/ms711683(v=vs.85).aspx) result set.