### PR TITLE
Fix binding of SQL_DECIMAL/SQL_NUMERIC type as character data

### DIFF
--- a/src/nanodbc.cpp
+++ b/src/nanodbc.cpp
@@ -2627,11 +2627,18 @@ private:
                 break;
             case SQL_DOUBLE:
             case SQL_FLOAT:
-            case SQL_DECIMAL:
             case SQL_REAL:
-            case SQL_NUMERIC:
                 col.ctype_ = SQL_C_DOUBLE;
                 col.clen_ = sizeof(double);
+                break;
+            case SQL_DECIMAL:
+            case SQL_NUMERIC:
+                col.ctype_ = SQL_C_CHAR;
+                // SQL column size defines number of digits without the decimal mark
+                // and without minus sign which may also occur.
+                // We need to adjust buffer length allow space for null-termination character
+                // as well as the fractional part separator and the minus sign.
+                col.clen_ = (col.sqlsize_ + 1 + 1 + 1) * sizeof(SQLCHAR);
                 break;
             case SQL_DATE:
             case SQL_TYPE_DATE:

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -427,6 +427,86 @@ TEST_CASE_METHOD(mssql_fixture, "test_datetime", "[mssql][datetime]")
     }
 }
 
+TEST_CASE_METHOD(mssql_fixture, "test_decimal", "[mssql][decimal]")
+{
+    auto connection = connect();
+    create_table(connection, NANODBC_TEXT("test_decimal"), NANODBC_TEXT("(d decimal(19,4))"));
+
+    // insert
+    {
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_decimal(d) values (-922337203685477.5808);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_decimal(d) values (0);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_decimal(d) values (1.23);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_decimal(d) values (922337203685477.5807);"));
+    }
+
+    // select
+    {
+        auto result =
+            execute(connection, NANODBC_TEXT("select d from test_decimal order by d asc;"));
+        REQUIRE(result.next());
+        auto d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("-922337203685477.5808")); // Min value of SQL data type
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT(".0000"));
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("1.2300"));
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("922337203685477.5807")); // Max value of SQL data type MONEY
+    }
+}
+
+TEST_CASE_METHOD(mssql_fixture, "test_money", "[mssql][decimal][money]")
+{
+    auto connection = connect();
+    create_table(connection, NANODBC_TEXT("test_money"), NANODBC_TEXT("(d money)"));
+
+    // insert
+    {
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_money(d) values (-922337203685477.5808);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_money(d) values (0);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_money(d) values (1.23);"));
+        execute(
+            connection,
+            NANODBC_TEXT("insert into test_money(d) values (922337203685477.5807);"));
+    }
+
+    // select
+    {
+        auto result =
+            execute(connection, NANODBC_TEXT("select d from test_money order by d asc;"));
+        REQUIRE(result.next());
+        auto d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("-922337203685477.5808")); // Min value of SQL data type MONEY
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT(".0000"));
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("1.2300"));
+        REQUIRE(result.next());
+        d = result.get<nanodbc::string_type>(0);
+        REQUIRE(d == NANODBC_TEXT("922337203685477.5807")); // Max value of SQL data type MONEY
+    }
+}
+
 TEST_CASE_METHOD(mssql_fixture, "test_datetime2", "[mssql][datetime]")
 {
     auto connection = connect();

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -777,12 +777,11 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(
                 (result.column_datatype(1) == SQL_DECIMAL ||
                  result.column_datatype(1) == SQL_NUMERIC));
-            REQUIRE(result.column_c_datatype(1) == SQL_C_DOUBLE);
+            REQUIRE(result.column_c_datatype(1) == SQL_C_CHAR);
         }
         REQUIRE(result.column_size(1) == 7);
         // n numeric(7,3)
         REQUIRE(result.column_name(2) == NANODBC_TEXT("n"));
-        REQUIRE(result.column_c_datatype(2) == SQL_C_DOUBLE);
         REQUIRE(result.column_size(2) == 7);
         if (vendor_ == database_vendor::sqlite)
         {
@@ -790,6 +789,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(result.column_datatype(2) == 8); // FIXME: What is this type?
             // FIXME: SQLite ODBC mis-reports decimal digits?
             REQUIRE(result.column_decimal_digits(2) == 0);
+            REQUIRE(result.column_c_datatype(2) == SQL_C_DOUBLE);
         }
         else
         {
@@ -797,6 +797,7 @@ struct test_case_fixture : public base_test_fixture
                 (result.column_datatype(2) == SQL_DECIMAL ||
                  result.column_datatype(2) == SQL_NUMERIC));
             REQUIRE(result.column_decimal_digits(2) == 3);
+            REQUIRE(result.column_c_datatype(2) == SQL_C_CHAR);
         }
     }
 


### PR DESCRIPTION
Binding SQL fixed precision and scale data to C float-point value may lead to unexpected rounding or truncation errors, especially during retrieval of min or max values of particular SQL data types.

For example:
Max value of SQL Server data type [MONEY](https://msdn.microsoft.com/en-us/library/ms179882.aspx) is `922337203685477.5807`.
If the `MONEY` column is bound as `SQL_C_DOUBLE`, then the fetched value is rounded to an odd value of `922337203685477.6250`.

------

I have tested the fix against SQL Server only with the relevant test included.