### PR TITLE
Add CMake package configuration (feature #243)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,9 +208,14 @@ if(NANODBC_STATIC OR WIN32)
   message(STATUS "nanodbc build: Enable nanodbc target - STATIC")
 else()
   add_library(nanodbc SHARED src/nanodbc.cpp src/nanodbc.h)
-  target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
   message(STATUS "nanodbc build: Enable nanodbc target - SHARED")
 endif()
+
+target_link_libraries(nanodbc ${Boost_LIBRARIES} ${ODBC_LIBRARIES})
+
+target_include_directories(nanodbc INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include>) # <prefix>/include
 
 if(UNIX)
   set_target_properties(nanodbc PROPERTIES
@@ -222,17 +227,30 @@ endif()
 ## install targets
 ########################################
 if(NANODBC_INSTALL)
+  set(NANODBC_CONFIG nanodbc-config)
+  # 'make install' to the correct location
   if(NANODBC_STATIC)
     install(TARGETS nanodbc
-      ARCHIVE DESTINATION lib
-      LIBRARY DESTINATION lib)
-  else()
-    install(TARGETS nanodbc
-      RUNTIME DESTINATION bin
+      EXPORT ${NANODBC_CONFIG} # associate installed target files with export
+      INCLUDES DESTINATION include
       LIBRARY DESTINATION lib
       ARCHIVE DESTINATION lib)
+  else()
+    install(TARGETS nanodbc
+      EXPORT ${NANODBC_CONFIG} # associate installed target files with export
+      INCLUDES DESTINATION include
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      RUNTIME DESTINATION bin) # for Windows
   endif()
+  # Install public include headers
   install(FILES src/nanodbc.h DESTINATION include)
+  # Make project importable from the install directory
+  ## Generate and install *-config.cmake exporting targets from install tree.
+  install(EXPORT ${NANODBC_CONFIG} DESTINATION cmake)
+  # Make project importable from the build directory
+  ## Generate file *-config.cmake exporting targets from build tree.
+  export(TARGETS nanodbc FILE ${NANODBC_CONFIG}.cmake)
 endif()
 message(STATUS "nanodbc build: Enable install target - ${NANODBC_INSTALL}")
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -170,8 +170,15 @@ test_script:
 after_test:
   - ps: |
       if ($env:GENERATOR -Match "NMake") {
-        'Write-Host "Running install:" -ForegroundColor Magenta'
+        Write-Host "Running install:" -ForegroundColor Magenta
         cmake --build . --target install
+      }
+  - ps: |
+      if ($env:GENERATOR -Match "NMake") {
+        Write-Host "Building examples/client based on nanodbc package configuration:" -ForegroundColor Magenta
+        cd $env:APPVEYOR_BUILD_FOLDER\examples\client
+        cmake.exe -G $env:GENERATOR -DCMAKE_BUILD_TYPE=Release .
+        cmake --build . --config Release
       }
 
 # If you need to debug AppVeyor session (https://www.appveyor.com/docs/how-to/rdp-to-build-worker), then:

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(nanodbc-client CXX)
+
+if (NOT TARGET nanodbc)
+  find_package(nanodbc CONFIG REQUIRED)
+endif()
+
+message(STATUS "nanodbc package found - ${nanodbc_FOUND}")
+message(STATUS "nanodbc package directory - ${nanodbc_DIR}")
+
+add_executable(nanodbc_client nanodbc_client.cpp)
+target_link_libraries(nanodbc_client nanodbc)

--- a/examples/client/nanodbc_client.cpp
+++ b/examples/client/nanodbc_client.cpp
@@ -1,0 +1,23 @@
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <nanodbc.h>
+
+int main(int argc, char* argv[]) try
+{
+    nanodbc::connection conn;
+    try
+    {
+        std::cout << conn.driver_name() << std::endl;
+    }
+    catch (nanodbc::database_error const& e)
+    {
+        std::cout << "Connection not open - OK" << std::endl;
+    }
+    return EXIT_SUCCESS;
+}
+catch (std::exception const& e)
+{
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
- Exports nanodbc target
- Generates nanodbc-config.cmake
- Make project importable from both, install and build directory

Add examples/client project with example of nanodbc target importing.

-----

Addresses feature request #243

## TODO

- [x] Bump CMake requirement to 3.0.0 or later (3d8e42752f06bba41603bb9fc2eeb8ea4d025602)
- [x] Export `nanodbc` target
- [x] Make project importable from the install directory
- [x] Make project importable from the build directory
- [x] Add example of client using imported `nanodbc` target.
- [x] Add CI build running install target (AppVeyor only)
- [x] Building the new client relying on `find_package(nanodbc)` as part of CI build

------

AppVeyor build [1.0.435](https://ci.appveyor.com/project/lexicalunit/nanodbc/build/1.0.435/job/whb5qgjq7bwpytnf) shows the nanodbc package config file in action:

* Running install:
```
[  5%] Built target nanodbc
...
[100%] Built target example_table_schema
Install the project...
-- Install configuration: "Release"
-- Installing: C:/Program Files (x86)/nanodbc/lib/nanodbc.lib
-- Installing: C:/Program Files (x86)/nanodbc/include/nanodbc.h
-- Installing: C:/Program Files (x86)/nanodbc/cmake/nanodbc-config.cmake
-- Installing: C:/Program Files (x86)/nanodbc/cmake/nanodbc-config-release.cmake
```

* Building examples/client based on nanodbc package configuration and `find_package(nanodbc)` call:
```
-- The CXX compiler identification is MSVC 19.0.24215.1
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- nanodbc package found - 1
-- nanodbc package directory - C:/Program Files (x86)/nanodbc/cmake
-- Configuring done
-- Generating done
-- Build files have been written to: C:/projects/nanodbc/examples/client
Scanning dependencies of target nanodbc_client
[ 50%] Building CXX object CMakeFiles/nanodbc_client.dir/nanodbc_client.cpp.obj
nanodbc_client.cpp
C:\projects\nanodbc\examples\client\nanodbc_client.cpp(13): warning C4101: 'e': unreferenced local variable
[100%] Linking CXX executable nanodbc_client.exe
[100%] Built target nanodbc_client
```

/cc @lexicalunit 