### PR TITLE
COLUMN_SIZE for bytea now equals SQL_NO_TOTAL(-4) by default.

### DIFF
--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -458,12 +458,15 @@ struct test_case_fixture : public base_test_fixture
                  columns.sql_data_type() == SQL_BINARY));        // SQLite
             // SQL Server: if n is not specified in [var]binary(n), the default length is 1
             // PostgreSQL: bytea default length is reported as 255,
-            // unless ByteaAsLongVarBinary=1 option is specified in connection string.
+            // unless ByteaAsLongVarBinary=1 (default) option is specified in connection string.
+            // See https://github.com/lexicalunit/nanodbc/issues/249
             // Vertica: column size is 80
             if (contains_string(dbms, NANODBC_TEXT("SQLite")))
                 REQUIRE(columns.column_size() == 0);
             else
-                REQUIRE(columns.column_size() > 0); // no need to test exact value
+                REQUIRE(
+                    (columns.column_size() > 0 ||
+                     columns.column_size() == SQL_NO_TOTAL)); // no need to test exact value
 
             // expect no more records
             REQUIRE(!columns.next());


### PR DESCRIPTION
Address change in psqlODBC behaviour in version 09.06:

- in psqlODBC 09.05 and earlier, bytea default size is reported as 255, unless ByteaAsLongVarBinary=1 option is specified.

- in 09.06 and later, default of ByteaAsLongVarBinary changed from 0 to 1.

Apparently, that affects `COLUMN_SIZE` value reported by `SQLColumns` for `bytea`.

Fixes #249