### PR TITLE
Refactor CMake options to default value OFF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,52 +91,52 @@ matrix:
           build_command: cmake --build ./build.coverity
           branch_pattern: coverity_scan
       compiler: gcc
-      env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF COVERITY=ON ENABLE_LIBCXX=OFF
+      env: DB=sqlite DISABLE_LIBCXX=ON COVERITY=ON
       os: linux
     - addons: *sqlite
       compiler: gcc
-      env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF BUILD_SHARED_LIBS=ON ENABLE_LIBCXX=OFF
+      env: DB=sqlite BUILD_SHARED_LIBS=ON DISABLE_LIBCXX=ON
       os: linux
     - addons: *sqlite
       compiler: gcc
-      env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON ENABLE_LIBCXX=OFF
+      env: DB=sqlite ENABLE_BOOST=ON DISABLE_LIBCXX=ON
       os: linux
     - addons: *mysql
       compiler: gcc
-      env: DB=mysql USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+      env: DB=mysql DISABLE_LIBCXX=ON
       os: linux
     - addons: *mysql
       compiler: gcc
-      env: DB=mysql USE_UNICODE=OFF USE_BOOST_CONVERT=ON ENABLE_LIBCXX=OFF
+      env: DB=mysql ENABLE_BOOST=ON DISABLE_LIBCXX=ON
       os: linux
     - addons: *mysql
       compiler: gcc
-      env: DB=mysql USE_UNICODE=ON USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+      env: DB=mysql ENABLE_UNICODE=ON DISABLE_LIBCXX=ON
       os: linux
     - addons: *mysql
       compiler: gcc
-      env: DB=mysql USE_UNICODE=ON USE_BOOST_CONVERT=ON ENABLE_LIBCXX=OFF
+      env: DB=mysql ENABLE_UNICODE=ON ENABLE_BOOST=ON DISABLE_LIBCXX=ON
       os: linux
     - addons: *postgresql
       compiler: gcc
-      env: DB=postgresql USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+      env: DB=postgresql DISABLE_LIBCXX=ON
       os: linux
     - addons: *mariadb
       compiler: gcc
-      env: DB=mariadb USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+      env: DB=mariadb DISABLE_LIBCXX=ON
       os: linux
     - addons: *vertica
       compiler: gcc
-      env: DB=vertica USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+      env: DB=vertica DISABLE_LIBCXX=ON
       os: linux
     - compiler: clang
-      env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=ON
+      env: DB=sqlite
       os: osx
     - compiler: clang
-      env: DB=sqlite USE_UNICODE=OFF USE_BOOST_CONVERT=ON ENABLE_LIBCXX=ON
+      env: DB=sqlite ENABLE_BOOST=ON
       os: osx
   allow_failures:
-    - env: DB=mariadb USE_UNICODE=OFF USE_BOOST_CONVERT=OFF ENABLE_LIBCXX=OFF
+    - env: DB=mariadb DISABLE_LIBCXX=ON
 
 # before_install runs after matrix.addons.apt installation targets in the matrix
 before_install:
@@ -151,7 +151,6 @@ before_install:
 
 before_script:
   - source "${TRAVIS_BUILD_DIR}/utility/ci/travis/before_script.$DB.sh"
-  - if [[ -z ${BUILD_SHARED_LIBS+x} ]]; then export BUILD_SHARED_LIBS=OFF; fi
   - if [[ -f /etc/odbcinst.ini ]]; then export ODBCSYSINI=/etc; fi
   - if [[ -f /etc/odbc.ini ]]; then export ODBCINI=/etc/odbc.ini; fi
   - odbcinst -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,20 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(nanodbc CXX)
 
+# NOTE: All options follow CMake convention:
+#       If no initial value is provided, OFF is used.
+
+# CMake standard options
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
-option(NANODBC_USE_UNICODE "build with unicode support turned on" OFF)
-option(NANODBC_USE_BOOST_CONVERT "build using Boost.Locale for string convert" OFF)
-option(NANODBC_HANDLE_NODATA_BUG "enable special handling for SQL_NO_DATA (required for vertica)" OFF)
-option(NANODBC_DISABLE_ASYNC "disable async features entirely (may help resolve issues in VS2015 builds)" OFF)
-option(NANODBC_EXAMPLES "build examples" ON)
-option(NANODBC_TEST "build tests" ON)
-option(NANODBC_INSTALL "generate install target" ON)
-option(NANODBC_ENABLE_LIBCXX "Use libc++ if available." ON)
+# nanodbc specific options
+option(NANODBC_DISABLE_ASYNC "Disable async features entirely" OFF)
+option(NANODBC_DISABLE_EXAMPLES "Do not build examples" OFF)
+option(NANODBC_DISABLE_INSTALL "Do not generate install target" OFF)
+option(NANODBC_DISABLE_LIBCXX "Do not use libc++, if available." OFF)
+option(NANODBC_DISABLE_TESTS "Do not build tests" OFF)
+option(NANODBC_ENABLE_BOOST "Use Boost for Unicode string convertions (requires Boost.Locale)" OFF)
+option(NANODBC_ENABLE_UNICODE "Enable Unicode support" OFF)
+option(NANODBC_ENABLE_WORKAROUND_NODATA "Enable SQL_NO_DATA workaround (see Issue #33)" OFF)
 
 ########################################
 ## nanodbc version
@@ -30,7 +35,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
   include(CheckCXXCompilerFlag)
-  if(NANODBC_ENABLE_LIBCXX)
+  if(NOT NANODBC_DISABLE_LIBCXX)
     check_cxx_compiler_flag("-stdlib=libc++" CXX_SUPPORTS_STDLIB)
     if(CXX_SUPPORTS_STDLIB)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
@@ -71,30 +76,29 @@ else()
   add_definitions(-DNANODBC_ODBC_VERSION=${NANODBC_ODBC_VERSION})
 endif()
 
-if(NANODBC_USE_UNICODE)
-  add_definitions(-DNANODBC_USE_UNICODE)
+if(NANODBC_DISABLE_ASYNC)
+  add_definitions(-DNANODBC_DISABLE_ASYNC)
+endif()
+message(STATUS "nanodbc feature: Disable async features - ${NANODBC_DISABLE_ASYNC}")
+
+if(NANODBC_ENABLE_UNICODE)
+  add_definitions(-DNANODBC_ENABLE_UNICODE)
   if(MSVC)
     # Sets "Use Unicode Character Set" property in Visual Studio projects
     add_definitions(-DUNICODE -D_UNICODE)
   endif()
 endif()
-message(STATUS "nanodbc feature: Unicode support - ${NANODBC_USE_UNICODE}")
+message(STATUS "nanodbc feature: Enable Unicode - ${NANODBC_ENABLE_UNICODE}")
 
-if(NANODBC_USE_BOOST_CONVERT)
-  add_definitions(-DNANODBC_USE_BOOST_CONVERT)
+if(NANODBC_ENABLE_BOOST)
+  add_definitions(-DNANODBC_ENABLE_BOOST)
 endif()
-message(STATUS "nanodbc feature: Boost string convert - ${NANODBC_USE_BOOST_CONVERT}")
+message(STATUS "nanodbc feature: Enable Boost - ${NANODBC_ENABLE_BOOST}")
 
-if(NANODBC_HANDLE_NODATA_BUG)
-  add_definitions(-DNANODBC_HANDLE_NODATA_BUG)
+if(NANODBC_ENABLE_WORKAROUND_NODATA)
+  add_definitions(-DNANODBC_ENABLE_WORKAROUND_NODATA)
 endif()
-message(STATUS "nanodbc feature: Handle SQL_NO_DATA bug - ${NANODBC_HANDLE_NODATA_BUG}")
-
-if(NANODBC_DISABLE_ASYNC)
-  message(STATUS "Disable async features: Yes")
-  add_definitions(-DNANODBC_DISABLE_ASYNC)
-endif()
-message(STATUS "nanodbc feature: Disable async features - ${NANODBC_DISABLE_ASYNC}")
+message(STATUS "nanodbc feature: Enable SQL_NO_DATA bug workaround - ${NANODBC_ENABLE_WORKAROUND_NODATA}")
 
 ########################################
 ## find unixODBC or iODBC config binary
@@ -143,7 +147,7 @@ if(UNIX)
       set(CMAKE_FLAGS "${CMAKE_FLAGS} ${ODBC_CFLAGS}")
       execute_process(COMMAND ${ODBC_CONFIG} --libs
         OUTPUT_VARIABLE ODBC_LINK_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
-      if(NANODBC_USE_UNICODE)
+      if(NANODBC_ENABLE_UNICODE)
         add_definitions(-DNANODBC_USE_IODBC_WIDE_STRINGS)
       endif()
     endif()
@@ -172,7 +176,7 @@ endif()
 ########################################
 ## find Boost if necessary
 ########################################
-if(NANODBC_USE_BOOST_CONVERT)
+if(NANODBC_ENABLE_BOOST)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_MULTITHREADED ON)
   find_package(Boost COMPONENTS locale REQUIRED)
@@ -231,7 +235,7 @@ endif()
 ########################################
 ## install targets
 ########################################
-if(NANODBC_INSTALL)
+if(NOT NANODBC_DISABLE_INSTALL)
   set(NANODBC_CONFIG nanodbc-config)
   # 'make install' to the correct location
   if(BUILD_SHARED_LIBS)
@@ -257,24 +261,24 @@ if(NANODBC_INSTALL)
   ## Generate file *-config.cmake exporting targets from build tree.
   export(TARGETS nanodbc FILE ${NANODBC_CONFIG}.cmake)
 endif()
-message(STATUS "nanodbc build: Enable install target - ${NANODBC_INSTALL}")
+message(STATUS "nanodbc build: Disable install target - ${NANODBC_DISABLE_INSTALL}")
 
 ########################################
 ## tests targets
 ########################################
-if(NANODBC_TEST)
+if(NOT NANODBC_DISABLE_TESTS)
   enable_testing()
   add_subdirectory(test)
   add_custom_target(check
     COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process --output-on-failure
     DEPENDS tests)
 endif()
-message(STATUS "nanodbc build: Enable tests target - ${NANODBC_TEST}")
+message(STATUS "nanodbc build: Disable tests target - ${NANODBC_DISABLE_TESTS}")
 
 ########################################
 ## examples targets
 ########################################
-if(NANODBC_EXAMPLES)
+if(NOT NANODBC_DISABLE_EXAMPLES)
   add_subdirectory(example)
 endif()
-message(STATUS "nanodbc build: Enable examples target - ${NANODBC_EXAMPLES}")
+message(STATUS "nanodbc build: Disable examples target - ${NANODBC_DISABLE_EXAMPLES}")

--- a/README.md
+++ b/README.md
@@ -117,22 +117,25 @@ make install # installs nanodbc.h and shared library
 
 The following build options are available via [CMake command-line option][cmake-docs] `-D`. If you
 are not using CMake to build nanodbc, you will need to set the corresponding `-D` compile define
-flags yourself. You will need to configure your build to use [boost][boost] if you want to use the
-`NANODBC_USE_BOOST_CONVERT` option.
+flags yourself.
 
-| CMake&nbsp;Option                     | Possible&nbsp;Values  | Default       | Details |
-| ------------------------------------- | --------------------- | ------------- | ------- |
-| `NANODBC_DISABLE_ASYNC`               | `OFF` or `ON`         | `OFF`         | Disables all async features. Can resolve build issues in older ODBC versions. |
-| `NANODBC_ENABLE_LIBCXX`               | `OFF` or `ON`         | `ON`          | Enables usage of libc++ if found on the system. |
-| `NANODBC_EXAMPLES`                    | `OFF` or `ON`         | `ON`          | Enables building of examples. |
-| `NANODBC_HANDLE_NODATA_BUG`           | `OFF` or `ON`         | `OFF`         | Provided to resolve issue [#33](https://github.com/lexicalunit/nanodbc/issues/33), details [in this commit](https://github.com/lexicalunit/nanodbc/commit/918d73cdf12d5903098381344eecde8e7d5d896e). |
-| `NANODBC_INSTALL`                     | `OFF` or `ON`         | `ON`          | Enables install target. |
-| `NANODBC_ODBC_VERSION`                | `SQL_OV_ODBC3[...]`   | See Details   | **[Optional]** Sets the ODBC version macro for nanodbc to use. Default is `SQL_OV_ODBC3_80` if available, otherwise `SQL_OV_ODBC3`. |
-| `NANODBC_TEST`                        | `OFF` or `ON`         | `ON`          | Enables tests target (alias `check`). |
-| `NANODBC_USE_BOOST_CONVERT`           | `OFF` or `ON`         | `OFF`         | Provided as workaround to issue [#44](https://github.com/lexicalunit/nanodbc/issues/44). |
-| `NANODBC_USE_UNICODE`                 | `OFF` or `ON`         | `OFF`         | Enables full unicode support. `nanodbc::string` becomes `std::u16string` or `std::u32string`. |
+All boolean options follow the CMake [OPTION][cmake-option] default value convention: if no initial value is provided, `OFF` is used.
 
 Use the standard CMake option `-DBUILD_SHARED_LIBS=ON` to build nanodbc as shared library.
+
+If you need to use the `NANODBC_ENABLE_BOOST=ON` option, you will have to configure your environment to use [Boost][boost].
+
+| CMake&nbsp;Option                  | Possible&nbsp;Values | Details |
+| -----------------------------------| ---------------------| ------- |
+| `NANODBC_DISABLE_ASYNC`            | `OFF` or `ON`        | Disable all async features. May resolve build issues in older ODBC versions. |
+| `NANODBC_DISABLE_EXAMPLES`         | `OFF` or `ON`        | Do not build examples. |
+| `NANODBC_DISABLE_INSTALL`          | `OFF` or `ON`        | Do not generate install target. |
+| `NANODBC_DISABLE_LIBCXX`           | `OFF` or `ON`        | Do not use libc++, if available on the system. |
+| `NANODBC_DISABLE_TESTS`            | `OFF` or `ON`        | Do not build tests. |
+| `NANODBC_ENABLE_BOOST`             | `OFF` or `ON`        | Use Boost for Unicode string convertions (requires [Boost.Locale][boost-locale]). Workaround to issue [#44](https://github.com/lexicalunit/nanodbc/issues/44). |
+| `NANODBC_ENABLE_UNICODE`           | `OFF` or `ON`        | Enable Unicode support. `nanodbc::string` becomes `std::u16string` or `std::u32string`. |
+| `NANODBC_ENABLE_WORKAROUND_NODATA` | `OFF` or `ON`        | Enable `SQL_NO_DATA` workaround to issue [#33](https://github.com/lexicalunit/nanodbc/issues/33). |
+| `NANODBC_ODBC_VERSION`             | `SQL_OV_ODBC3[...]`  | Forces ODBC version to use. Default is `SQL_OV_ODBC3_80` if available, otherwise `SQL_OV_ODBC3`. |
 
 ## Note About iODBC
 
@@ -294,11 +297,13 @@ deemed "stable" based on suitable criteria.**
 [nanodbc-releases]:     https://github.com/lexicalunit/nanodbc/releases
 
 [boost]:        http://www.boost.org/
+[boost-locale]: http://www.boost.org/doc/libs/release/libs/locale/
 [brew]:         http://brew.sh/
 [catch]:        https://github.com/philsquared/Catch
 [clang-format]: http://clang.llvm.org/docs/ClangFormat.html
 [cmake-docs]:   https://cmake.org/cmake/help/latest/manual/cmake.1.html
 [cmake]:        http://www.cmake.org/
+[cmake-option]: http://cmake.org/cmake/help/latest/command/option.html
 [cpp-core]:     https://github.com/isocpp/CppCoreGuidelines
 [cpp-std]:      https://isocpp.org/std/status
 [docker]:       https://www.docker.com/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,54 +26,33 @@ environment:
   matrix:
     - DB: SQLite
       G: "Visual Studio 14 2015"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: SQLite
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: SQLite
       G: "NMake Makefiles"
       P: x86-32
-      UNICODE: OFF
-      BOOST: OFF
-      NO_ASYNC: ON
+      DISABLE_ASYNC: ON
     - DB: MSSQL2016
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: MSSQL2016
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: ON
-      BOOST: OFF
+      ENABLE_UNICODE: ON
     - DB: MSSQL2014
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: MSSQL2008
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: MySQL
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: PostgreSQL
       G: "Visual Studio 14 2015 Win64"
-      UNICODE: OFF
-      BOOST: OFF
     - DB: SQLite
       G: "MinGW Makefiles"
       P: x86-32
-      UNICODE: OFF
-      BOOST: OFF
-      NO_ASYNC: ON
+      DISABLE_ASYNC: ON
     - DB: SQLite
       G: "MinGW Makefiles"
       P: x86-64
-      UNICODE: OFF
-      BOOST: OFF
-      NO_ASYNC: ON
+      DISABLE_ASYNC: ON
 
 matrix:
   allow_failures:
@@ -116,10 +95,13 @@ install:
       }
 
 before_build:
-  - ps: 'Write-Host "Running cmake: $env:G" -ForegroundColor Magenta'
-  - cmake.exe -G "%G%" -DCMAKE_BUILD_TYPE=Release -DNANODBC_USE_BOOST_CONVERT=%BOOST% -DNANODBC_USE_UNICODE=%UNICODE% -DNANODBC_DISABLE_ASYNC=%NO_ASYNC% -DNANODBC_HANDLE_NODATA_BUG=OFF -DNANODBC_INSTALL=ON %APPVEYOR_BUILD_FOLDER%
+  - ps: if (-not $env:DISABLE_ASYNC) { $env:DISABLE_ASYNC="OFF" }
+  - ps: if (-not $env:ENABLE_BOOST)   { $env:ENABLE_BOOST="OFF" }
+  - ps: if (-not $env:ENABLE_UNICODE) { $env:ENABLE_UNICODE="OFF" }
 
 build_script:
+  - ps: 'Write-Host "Running cmake: $env:G" -ForegroundColor Magenta'
+  - cmake.exe -G "%G%" -DCMAKE_BUILD_TYPE=Release -DNANODBC_ENABLE_BOOST=%ENABLE_BOOST% -DNANODBC_ENABLE_UNICODE=%ENABLE_UNICODE% -DNANODBC_DISABLE_ASYNC=%DISABLE_ASYNC% %APPVEYOR_BUILD_FOLDER%
   - ps: 'Write-Host "Running cmake --build:" -ForegroundColor Magenta'
   - cmake --build . --config Release
 

--- a/example/example_unicode_utils.h
+++ b/example/example_unicode_utils.h
@@ -11,12 +11,12 @@
 #error Examples do not support the iODBC wide strings
 #endif
 
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
 inline nanodbc::string_type convert(std::string const& in)
 {
     static_assert(
         sizeof(nanodbc::string_type::value_type) > 1,
-        "NANODBC_USE_UNICODE mode requires wide string_type");
+        "NANODBC_ENABLE_UNICODE mode requires wide string_type");
     nanodbc::string_type out;
 // Workaround for confirmed bug in VS2015.
 // See: https://social.msdn.microsoft.com/Forums/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -34,7 +34,7 @@
 #define NANODBC_ASSERT(expr) assert(expr)
 #endif
 
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_BOOST
 #include <boost/locale/encoding_utf.hpp>
 #else
 #include <codecvt>
@@ -113,7 +113,7 @@
 // MARK: Unicode -
 // clang-format on
 
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
 #define NANODBC_FUNC(f) f##W
 #define NANODBC_SQLCHAR SQLWCHAR
 #else
@@ -136,8 +136,8 @@ typedef std::u16string wide_string_type;
 typedef wide_string_type::value_type wide_char_t;
 
 #if defined(_MSC_VER)
-#ifndef NANODBC_USE_UNICODE
-// Disable unicode in sqlucode.h on Windows when NANODBC_USE_UNICODE
+#ifndef NANODBC_ENABLE_UNICODE
+// Disable unicode in sqlucode.h on Windows when NANODBC_ENABLE_UNICODE
 // is not defined. This is required because unicode is enabled by
 // default on many Windows systems.
 #define SQL_NOUNICODEMAP
@@ -256,7 +256,7 @@ inline std::size_t strarrlen(T (&a)[N])
 
 inline void convert(const wide_string_type& in, std::string& out)
 {
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_BOOST
     using boost::locale::conv::utf_to_utf;
     out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
 #else
@@ -273,10 +273,10 @@ inline void convert(const wide_string_type& in, std::string& out)
 #endif
 }
 
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
 inline void convert(const std::string& in, wide_string_type& out)
 {
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_BOOST
     using boost::locale::conv::utf_to_utf;
     out = utf_to_utf<wide_char_t>(in.c_str(), in.c_str() + in.size());
 // Workaround for confirmed bug in VS2015. See:
@@ -579,7 +579,7 @@ struct sql_ctype<double>
 template <>
 struct sql_ctype<nanodbc::string_type::value_type>
 {
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
     static const SQLSMALLINT value = SQL_C_WCHAR;
 #else
     static const SQLSMALLINT value = SQL_C_CHAR;
@@ -589,7 +589,7 @@ struct sql_ctype<nanodbc::string_type::value_type>
 template <>
 struct sql_ctype<nanodbc::string_type>
 {
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
     static const SQLSMALLINT value = SQL_C_WCHAR;
 #else
     static const SQLSMALLINT value = SQL_C_CHAR;
@@ -1480,7 +1480,7 @@ public:
         long timeout,
         statement& statement)
     {
-#ifdef NANODBC_HANDLE_NODATA_BUG
+#ifdef NANODBC_ENABLE_WORKAROUND_NODATA
         const RETCODE rc = just_execute_direct(conn, query, batch_operations, timeout, statement);
         if (rc == SQL_NO_DATA)
             return result();
@@ -1530,7 +1530,7 @@ public:
 
     result execute(long batch_operations, long timeout, statement& statement)
     {
-#ifdef NANODBC_HANDLE_NODATA_BUG
+#ifdef NANODBC_ENABLE_WORKAROUND_NODATA
         const RETCODE rc = just_execute(batch_operations, timeout, statement);
         if (rc == SQL_NO_DATA)
             return result();
@@ -2020,7 +2020,7 @@ void statement::statement_impl::bind_strings(
         {
             const string_type s_lhs(values + i * value_size, values + (i + 1) * value_size);
             const string_type s_rhs(null_sentry);
-#if NANODBC_USE_UNICODE
+#if NANODBC_ENABLE_UNICODE
             std::string narrow_lhs;
             narrow_lhs.reserve(s_lhs.size());
             convert(s_lhs, narrow_lhs);

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -137,9 +137,9 @@ namespace nanodbc
 
 /// @}
 
-// You must explicitly request Unicode support by defining NANODBC_USE_UNICODE at compile time.
+// You must explicitly request Unicode support by defining NANODBC_ENABLE_UNICODE at compile time.
 #ifndef DOXYGEN
-#ifdef NANODBC_USE_UNICODE
+#ifdef NANODBC_ENABLE_UNICODE
 #ifdef NANODBC_USE_IODBC_WIDE_STRINGS
 #define NANODBC_TEXT(s) U##s
 typedef std::u32string string_type;
@@ -172,14 +172,14 @@ typedef long null_type;
 /// \brief Creates a string literal of the type corresponding to `nanodbc::string_type`.
 ///
 /// By default, the macro maps to an unprefixed string literal.
-/// If building with options NANODBC_USE_UNICODE=ON and
+/// If building with options NANODBC_ENABLE_UNICODE=ON and
 /// NANODBC_USE_IODBC_WIDE_STRINGS=ON specified, then it prefixes a literal with U"...".
-/// If only NANODBC_USE_UNICODE=ON is specified, then:
+/// If only NANODBC_ENABLE_UNICODE=ON is specified, then:
 ///   * If building with Visual Studio, then the macro prefixes a literal with L"...".
 ///   * Otherwise, it prefixes a literal with u"...".
 #define NANODBC_TEXT(s) s
 
-/// \c string_type will be \c std::u16string or \c std::32string if \c NANODBC_USE_UNICODE defined.
+/// \c string_type will be \c std::u16string or \c std::32string if \c NANODBC_ENABLE_UNICODE defined.
 ///
 /// Otherwise it will be \c std::string.
 typedef unspecified - type string_type;

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -17,7 +17,7 @@
 #define NANODBC_OVERRIDE override
 #endif
 
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_BOOST
 #include <boost/locale/encoding_utf.hpp>
 #else
 #include <codecvt>
@@ -37,8 +37,8 @@ struct TestConfig
 {
     nanodbc::string_type get_connection_string() const
     {
-#ifdef NANODBC_USE_UNICODE
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_UNICODE
+#ifdef NANODBC_ENABLE_BOOST
         using boost::locale::conv::utf_to_utf;
         return utf_to_utf<char16_t>(
             connection_string_.c_str(), connection_string_.c_str() + connection_string_.size());
@@ -273,8 +273,8 @@ struct base_test_fixture
         value = env_value;
 #endif
 
-#ifdef NANODBC_USE_UNICODE
-#ifdef NANODBC_USE_BOOST_CONVERT
+#ifdef NANODBC_ENABLE_UNICODE
+#ifdef NANODBC_ENABLE_BOOST
         using boost::locale::conv::utf_to_utf;
         return utf_to_utf<char16_t>(value.c_str(), value.c_str() + value.size());
 // Workaround for confirmed bug in VS2015.

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -53,7 +53,7 @@ struct sqlite_fixture : public test_case_fixture
 // https://github.com/lexicalunit/nanodbc/pull/154
 // https://groups.google.com/forum/#!msg/catch-forum/7tIpgm8SvDA/1QZZESIuCQAJ
 // TODO: Uncomment as soon as the SIGSEGV issue has been fixed.
-#ifndef NANODBC_USE_UNICODE
+#ifndef NANODBC_ENABLE_UNICODE
 TEST_CASE_METHOD(sqlite_fixture, "test_affected_rows", "[sqlite][affected_rows]")
 {
     nanodbc::connection conn = connect();

--- a/utility/built.bat
+++ b/utility/built.bat
@@ -17,7 +17,7 @@ set NANODBC_TEST_CONNSTR_MSSQL=Driver={ODBC Driver 11 for SQL Server};Server=(lo
 set NANODBC_TEST_CONNSTR_MYSQL=Driver={MySQL ODBC 5.3 Unicode Driver};Database=vagrant;Server=localhost;User=vagrant;Password=vagrant;Option=3;
 set NANODBC_TEST_CONNSTR_PGSQL=Driver={PostgreSQL Unicode(x64)};Server=localhost;Database=vagrant;UID=vagrant;PWD=vagrant;
 setlocal
-set NANODBC_INSTALL=OFF
+set NANODBC_DISABLE_INSTALL=ON
 set BOOST_ROOT=C:/local/boost_1_59_0
 rem #######################################################
 
@@ -45,9 +45,8 @@ mkdir %BUILDDIR%
 pushd %BUILDDIR%
 "C:\Program Files\CMake\bin\cmake.exe" ^
     -G %GENERATOR% ^
-    -DNANODBC_USE_UNICODE=ON ^
-    -DNANODBC_TEST=ON ^
-    -DNANODBC_INSTALL=%NANODBC_INSTALL% ^
+    -DNANODBC_ENABLE_UNICODE=ON ^
+    -DNANODBC_DISABLE_INSTALL=%NANODBC_DISABLE_INSTALL% ^
     -DBOOST_ROOT:PATH=%BOOST_ROOT% ^
     -DBOOST_LIBRARYDIR:PATH=%BOOST_ROOT%/lib%NANOP%-msvc-14.0 ^
     ..

--- a/utility/ci/travis/script.sh
+++ b/utility/ci/travis/script.sh
@@ -1,12 +1,28 @@
 #!/bin/bash -ue
 
+if [[ -z ${BUILD_SHARED_LIBS+v} ]]; then
+    export BUILD_SHARED_LIBS=OFF
+fi
+
+if [[ -z ${ENABLE_UNICODE+v} ]]; then
+    export ENABLE_UNICODE=OFF
+fi
+
+if [[ -z ${ENABLE_BOOST+v} ]]; then
+    export ENABLE_BOOST=OFF
+fi
+
+if [[ -z ${DISABLE_LIBCXX+v} ]]; then
+    export DISABLE_LIBCXX=OFF
+fi
+
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
-      -DNANODBC_USE_UNICODE=${USE_UNICODE} \
-      -DNANODBC_USE_BOOST_CONVERT=${USE_BOOST_CONVERT} \
-      -DNANODBC_ENABLE_LIBCXX=${ENABLE_LIBCXX} \
+      -DNANODBC_ENABLE_UNICODE=${ENABLE_UNICODE} \
+      -DNANODBC_ENABLE_BOOST=${ENABLE_BOOST} \
+      -DNANODBC_DISABLE_LIBCXX=${DISABLE_LIBCXX} \
       ..
 make
 cd test


### PR DESCRIPTION
Follow CMake convention for `OPTION` semantic:

> if an option or preprocessor definition is not specified, it is always `OFF`.

Closes #259