### PR TITLE
Rename nanodbc::string_type to nanodbc::string

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Under Windows `sizeof(wchar_t) == sizeof(SQLWCHAR) == 2`, yet on Unix systems
 `sizeof(wchar_t) == 4`. On unixODBC, `sizeof(SQLWCHAR) == 2` while on iODBC,
 `sizeof(SQLWCHAR) == sizeof(wchar_t) == 4`. This leads to incompatible ABIs between applications
 and drivers. If building against iODBC and the build option `NANODBC_USE_UNICODE` is `ON`, then
-`nanodbc::string_type` will be `std::u32string`. In **ALL** other cases it will be `std::u16string`.
+`nanodbc::string` will be `std::u32string`. In **ALL** other cases it will be `std::u16string`.
 
 Continuous integration tests run on [Travis-CI][travis]. The build platform does not make available
 a Unicode-enabled iODBC driver. As such there is no guarantee that tests will pass in entirety on a

--- a/example/example_unicode_utils.h
+++ b/example/example_unicode_utils.h
@@ -12,16 +12,16 @@
 #endif
 
 #ifdef NANODBC_ENABLE_UNICODE
-inline nanodbc::string_type convert(std::string const& in)
+inline nanodbc::string convert(std::string const& in)
 {
     static_assert(
-        sizeof(nanodbc::string_type::value_type) > 1,
-        "NANODBC_ENABLE_UNICODE mode requires wide string_type");
-    nanodbc::string_type out;
+        sizeof(nanodbc::string::value_type) > 1,
+        "NANODBC_ENABLE_UNICODE mode requires wide string");
+    nanodbc::string out;
 // Workaround for confirmed bug in VS2015 and VS2017 too
 // See: https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
-    using wide_char_t = nanodbc::string_type::value_type;
+    using wide_char_t = nanodbc::string::value_type;
     auto s =
         std::wstring_convert<std::codecvt_utf8_utf16<wide_char_t>, wide_char_t>().from_bytes(in);
     auto p = reinterpret_cast<wide_char_t const*>(s.data());
@@ -32,14 +32,14 @@ inline nanodbc::string_type convert(std::string const& in)
     return out;
 }
 
-inline std::string convert(nanodbc::string_type const& in)
+inline std::string convert(nanodbc::string const& in)
 {
-    static_assert(sizeof(nanodbc::string_type::value_type) > 1, "string_type must be wide");
+    static_assert(sizeof(nanodbc::string::value_type) > 1, "string must be wide");
     std::string out;
 // Workaround for confirmed bug in VS2015 and VS2017 too
 // See: https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
 #if defined(_MSC_VER) && (_MSC_VER >= 1900)
-    using wide_char_t = nanodbc::string_type::value_type;
+    using wide_char_t = nanodbc::string::value_type;
     std::wstring_convert<std::codecvt_utf8_utf16<wide_char_t>, wide_char_t> convert;
     auto p = reinterpret_cast<const wide_char_t*>(in.data());
     out = convert.to_bytes(p, p + in.size());
@@ -49,7 +49,7 @@ inline std::string convert(nanodbc::string_type const& in)
     return out;
 }
 #else
-inline nanodbc::string_type convert(std::string const& in)
+inline nanodbc::string convert(std::string const& in)
 {
     return in;
 }
@@ -62,7 +62,7 @@ inline std::string any_to_string(T const& t)
 }
 
 template <>
-inline std::string any_to_string<nanodbc::string_type>(nanodbc::string_type const& t)
+inline std::string any_to_string<nanodbc::string>(nanodbc::string const& t)
 {
     return convert(t);
 }

--- a/example/northwind.cpp
+++ b/example/northwind.cpp
@@ -1,4 +1,4 @@
-#include "example_unicode_utils.h"
+﻿#include "example_unicode_utils.h"
 #include <nanodbc/nanodbc.h>
 
 #include <iostream>
@@ -21,8 +21,8 @@ int main()
 
         for (int i = 1; row.next(); ++i)
         {
-            cout << i << " :" << convert(row.get<string_type>(0)) << " "
-                 << convert(row.get<string_type>(1)) << " " << convert(row.get<string_type>(2))
+            cout << i << " :" << convert(row.get<nanodbc::string>(0)) << " "
+                 << convert(row.get<nanodbc::string>(1)) << " " << convert(row.get<nanodbc::string>(2))
                  << " " << endl;
         }
     }

--- a/example/rowset_iteration.cpp
+++ b/example/rowset_iteration.cpp
@@ -1,4 +1,4 @@
-#include "example_unicode_utils.h"
+﻿#include "example_unicode_utils.h"
 #include <nanodbc/nanodbc.h>
 
 #include <algorithm>
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace nanodbc;
 
-void usage(ostream& out, string const& binary_name)
+void usage(ostream& out, std::string const& binary_name)
 {
     out << "usage: " << binary_name << " connection_string" << endl;
 }
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
         // "Driver={ODBC Driver 11 for SQL Server};
         //  Server=xxx.sqlserver.net;Database=mydb;UID=joe;PWD=secret;"
         auto const connection_string(convert(argv[1]));
-        connection conn(connection_string);
+        nanodbc::connection conn(connection_string);
 
         // Create table
         {

--- a/example/table_schema.cpp
+++ b/example/table_schema.cpp
@@ -147,13 +147,13 @@ int main(int argc, char* argv[])
         //  Server=xxx.sqlserver.net;Database=mydb;UID=joe;PWD=secret;"
         auto const connection_string(convert(argv[1]));
         auto const table_name(convert(argv[2]));
-        nanodbc::string_type schema_name;
+        nanodbc::string schema_name;
         if (argc == 4)
             schema_name = convert(argv[3]);
 
         connection conn(connection_string);
         catalog cat(conn);
-        auto cols = cat.find_columns(nanodbc::string_type(), table_name, schema_name);
+        auto cols = cat.find_columns(nanodbc::string(), table_name, schema_name);
         while (cols.next())
         {
             if (cols.ordinal_position() == 1)

--- a/example/usage.cpp
+++ b/example/usage.cpp
@@ -1,4 +1,4 @@
-#include "example_unicode_utils.h"
+﻿#include "example_unicode_utils.h"
 #include <nanodbc/nanodbc.h>
 
 #include <algorithm>
@@ -10,7 +10,7 @@ using namespace nanodbc;
 
 void show(nanodbc::result& results);
 
-void run_test(nanodbc::string_type const& connection_string)
+void run_test(nanodbc::string const& connection_string)
 {
     // Establishing connections
     nanodbc::connection connection(connection_string);
@@ -39,7 +39,7 @@ void run_test(nanodbc::string_type const& connection_string)
             connection,
             NANODBC_TEXT("select a as first, b as second from simple_test where a = 1;"));
         results.next();
-        auto const value = results.get<nanodbc::string_type>(1);
+        auto const value = results.get<nanodbc::string>(1);
         cout << endl << results.get<int>(NANODBC_TEXT("first")) << ", " << convert(value) << endl;
     }
 
@@ -51,7 +51,7 @@ void run_test(nanodbc::string_type const& connection_string)
         prepare(statement, NANODBC_TEXT("insert into simple_test (a, b) values (?, ?);"));
         const int eight_int = 8;
         statement.bind(0, &eight_int);
-        nanodbc::string_type const eight_str = NANODBC_TEXT("eight");
+        nanodbc::string const eight_str = NANODBC_TEXT("eight");
         statement.bind(1, eight_str.c_str());
         execute(statement);
 
@@ -97,11 +97,11 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const size_t elements = 4;
 
-        nanodbc::string_type::value_type xdata[elements][10] = {
+        nanodbc::string::value_type xdata[elements][10] = {
             NANODBC_TEXT("this"), NANODBC_TEXT("is"), NANODBC_TEXT("a"), NANODBC_TEXT("test")};
         statement.bind_strings(0, xdata);
 
-        std::vector<nanodbc::string_type> x2data(xdata, xdata + elements);
+        std::vector<nanodbc::string> x2data(xdata, xdata + elements);
         statement.bind_strings(1, x2data);
 
         int ydata[elements] = {1, 2, 3, 4};
@@ -143,9 +143,9 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const int elements = 5;
         const int a_null = 0;
-        nanodbc::string_type::value_type const* b_null = NANODBC_TEXT("");
+        nanodbc::string::value_type const* b_null = NANODBC_TEXT("");
         int a_data[elements] = {0, 88, 0, 0, 0};
-        nanodbc::string_type::value_type b_data[elements][10] = {NANODBC_TEXT(""),
+        nanodbc::string::value_type b_data[elements][10] = {NANODBC_TEXT(""),
                                                                  NANODBC_TEXT("non-null"),
                                                                  NANODBC_TEXT(""),
                                                                  NANODBC_TEXT(""),
@@ -167,7 +167,7 @@ void run_test(nanodbc::string_type const& connection_string)
 
         const int elements = 2;
         int a_data[elements] = {0, 42};
-        nanodbc::string_type::value_type b_data[elements][10] = {
+        nanodbc::string::value_type b_data[elements][10] = {
             NANODBC_TEXT(""), NANODBC_TEXT("every")};
         bool nulls[elements] = {true, false};
 
@@ -199,20 +199,20 @@ void show(nanodbc::result& results)
     cout << endl;
 
     // show the column data for each row
-    nanodbc::string_type const null_value = NANODBC_TEXT("null");
+    nanodbc::string const null_value = NANODBC_TEXT("null");
     while (results.next())
     {
         cout << rows_displayed++ << "\t";
         for (short col = 0; col < columns; ++col)
         {
-            auto const value = results.get<nanodbc::string_type>(col, null_value);
+            auto const value = results.get<nanodbc::string>(col, null_value);
             cout << "(" << convert(value) << ")\t";
         }
         cout << endl;
     }
 }
 
-void usage(ostream& out, string const& binary_name)
+void usage(ostream& out, std::string const& binary_name)
 {
     out << "usage: " << binary_name << " connection_string" << endl;
 }

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -142,18 +142,18 @@ namespace nanodbc
 #ifdef NANODBC_ENABLE_UNICODE
 #ifdef NANODBC_USE_IODBC_WIDE_STRINGS
 #define NANODBC_TEXT(s) U##s
-typedef std::u32string string_type;
+typedef std::u32string string;
 #else
 #ifdef _MSC_VER
-typedef std::wstring string_type;
+typedef std::wstring string;
 #define NANODBC_TEXT(s) L##s
 #else
-typedef std::u16string string_type;
+typedef std::u16string string;
 #define NANODBC_TEXT(s) u##s
 #endif
 #endif
 #else
-typedef std::string string_type;
+typedef std::string string;
 #define NANODBC_TEXT(s) s
 #endif
 
@@ -169,7 +169,7 @@ typedef long null_type;
 #endif
 #else
 /// \def NANODBC_TEXT(s)
-/// \brief Creates a string literal of the type corresponding to `nanodbc::string_type`.
+/// \brief Creates a string literal of the type corresponding to `nanodbc::string`.
 ///
 /// By default, the macro maps to an unprefixed string literal.
 /// If building with options NANODBC_ENABLE_UNICODE=ON and
@@ -179,11 +179,11 @@ typedef long null_type;
 ///   * Otherwise, it prefixes a literal with u"...".
 #define NANODBC_TEXT(s) s
 
-/// \c string_type will be \c std::u16string or \c std::32string if \c NANODBC_ENABLE_UNICODE
+/// \c string will be \c std::u16string or \c std::32string if \c NANODBC_ENABLE_UNICODE
 /// defined.
 ///
 /// Otherwise it will be \c std::string.
-typedef unspecified - type string_type;
+typedef unspecified - type string;
 /// \c null_type will be \c int64_t for 64-bit compilations, otherwise \c long.
 typedef unspecified - type null_type;
 #endif
@@ -439,7 +439,7 @@ public:
     /// \param query The SQL query statement.
     /// \param timeout The number in seconds before query timeout. Default: 0 meaning no timeout.
     /// \see execute(), just_execute(), execute_direct(), just_execute_direct(), open(), prepare()
-    statement(class connection& conn, const string_type& query, long timeout = 0);
+    statement(class connection& conn, const string& query, long timeout = 0);
 
     /// \brief Copy constructor.
     statement(const statement& rhs);
@@ -492,7 +492,7 @@ public:
     /// \param timeout The number in seconds before query timeout. Default 0 meaning no timeout.
     /// \see open()
     /// \throws database_error
-    void prepare(class connection& conn, const string_type& query, long timeout = 0);
+    void prepare(class connection& conn, const string& query, long timeout = 0);
 
     /// \brief Prepares the given statement to execute its associated connection.
     /// \note If the statement is not open throws programming_error.
@@ -500,7 +500,7 @@ public:
     /// \param timeout The number in seconds before query timeout. Default 0 meaning no timeout.
     /// \see open()
     /// \throws database_error, programming_error
-    void prepare(const string_type& query, long timeout = 0);
+    void prepare(const string& query, long timeout = 0);
 
     /// \brief Sets the number in seconds before query timeout. Default is 0 indicating no timeout.
     /// \throws database_error
@@ -518,7 +518,7 @@ public:
     /// \see open(), prepare(), execute(), result, transaction
     class result execute_direct(
         class connection& conn,
-        const string_type& query,
+        const string& query,
         long batch_operations = 1,
         long timeout = 0);
 
@@ -539,7 +539,7 @@ public:
     /// \throws database_error
     /// \return Boolean: true if the event handle needs to be awaited, false is result is ready now.
     /// \see complete_prepare()
-    bool async_prepare(const string_type& query, void* event_handle, long timeout = 0);
+    bool async_prepare(const string& query, void* event_handle, long timeout = 0);
 
     /// \brief Completes a previously initiated asynchronous query preparation.
     ///
@@ -576,7 +576,7 @@ public:
     bool async_execute_direct(
         class connection& conn,
         void* event_handle,
-        const string_type& query,
+        const string& query,
         long batch_operations = 1,
         long timeout = 0);
 
@@ -636,7 +636,7 @@ public:
     /// \see open(), prepare(), execute(), execute_direct(), result, transaction
     void just_execute_direct(
         class connection& conn,
-        const string_type& query,
+        const string& query,
         long batch_operations = 1,
         long timeout = 0);
 
@@ -668,10 +668,10 @@ public:
     /// \throws database_error
     /// \return A result set object.
     class result procedure_columns(
-        const string_type& catalog,
-        const string_type& schema,
-        const string_type& procedure,
-        const string_type& column);
+        const string& catalog,
+        const string& schema,
+        const string& procedure,
+        const string& column);
 
     /// \brief Returns rows affected by the request or -1 if affected rows is not available.
     /// \throws database_error
@@ -809,7 +809,7 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        string_type::value_type const* values,
+        string::value_type const* values,
         std::size_t value_size,
         std::size_t batch_size,
         param_direction direction = PARAM_IN);
@@ -822,7 +822,7 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        std::vector<string_type> const& values,
+        std::vector<string> const& values,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
@@ -830,10 +830,10 @@ public:
     template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        string_type::value_type const (&values)[BatchSize][ValueSize],
+        string::value_type const (&values)[BatchSize][ValueSize],
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        auto param_values = reinterpret_cast<string::value_type const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, direction);
     }
 
@@ -841,18 +841,18 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        string_type::value_type const* values,
+        string::value_type const* values,
         std::size_t value_size,
         std::size_t batch_size,
-        string_type::value_type const* null_sentry,
+        string::value_type const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        std::vector<string_type> const& values,
-        string_type::value_type const* null_sentry,
+        std::vector<string> const& values,
+        string::value_type const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
@@ -860,11 +860,11 @@ public:
     template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        string_type::value_type const (&values)[BatchSize][ValueSize],
-        string_type::value_type const* null_sentry,
+        string::value_type const (&values)[BatchSize][ValueSize],
+        string::value_type const* null_sentry,
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        auto param_values = reinterpret_cast<string::value_type const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, null_sentry, direction);
     }
 
@@ -872,7 +872,7 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        string_type::value_type const* values,
+        string::value_type const* values,
         std::size_t value_size,
         std::size_t batch_size,
         bool const* nulls,
@@ -882,7 +882,7 @@ public:
     /// \see bind_strings
     void bind_strings(
         short param_index,
-        std::vector<string_type> const& values,
+        std::vector<string> const& values,
         bool const* nulls,
         param_direction direction = PARAM_IN);
 
@@ -891,11 +891,11 @@ public:
     template <std::size_t BatchSize, std::size_t ValueSize>
     void bind_strings(
         short param_index,
-        string_type::value_type const (&values)[BatchSize][ValueSize],
+        string::value_type const (&values)[BatchSize][ValueSize],
         bool const* nulls,
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string_type::value_type const*>(values);
+        auto param_values = reinterpret_cast<string::value_type const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, nulls, direction);
     }
 
@@ -968,9 +968,9 @@ public:
     /// \throws database_error
     /// \see connected(), connect()
     connection(
-        const string_type& dsn,
-        const string_type& user,
-        const string_type& pass,
+        const string& dsn,
+        const string& user,
+        const string& pass,
         long timeout = 0);
 
     /// \brief Create new connection object and immediately connect using the given connection
@@ -979,7 +979,7 @@ public:
     /// \param timeout Seconds before connection timeout. Default is 0 indicating no timeout.
     /// \throws database_error
     /// \see connected(), connect()
-    connection(const string_type& connection_string, long timeout = 0);
+    connection(const string& connection_string, long timeout = 0);
 
     /// \brief Automatically disconnects from the database and frees all associated resources.
     ///
@@ -995,9 +995,9 @@ public:
     /// \throws database_error
     /// \see connected()
     void connect(
-        const string_type& dsn,
-        const string_type& user,
-        const string_type& pass,
+        const string& dsn,
+        const string& user,
+        const string& pass,
         long timeout = 0);
 
     /// \brief Connect using the given connection string.
@@ -1005,7 +1005,7 @@ public:
     /// \param timeout Seconds before connection timeout. Default is 0 indicating no timeout.
     /// \throws database_error
     /// \see connected()
-    void connect(const string_type& connection_string, long timeout = 0);
+    void connect(const string& connection_string, long timeout = 0);
 
 #if !defined(NANODBC_DISABLE_ASYNC)
     /// \brief Initiate an asynchronous connection operation to the given data source.
@@ -1026,9 +1026,9 @@ public:
     /// \return Boolean: true if event handle needs to be awaited, false if connection is ready now.
     /// \see connected()
     bool async_connect(
-        const string_type& dsn,
-        const string_type& user,
-        const string_type& pass,
+        const string& dsn,
+        const string& user,
+        const string& pass,
         void* event_handle,
         long timeout = 0);
 
@@ -1047,7 +1047,7 @@ public:
     /// \throws database_error
     /// \return Boolean: true if event handle needs to be awaited, false if connection is ready now.
     /// \see connected()
-    bool async_connect(const string_type& connection_string, void* event_handle, long timeout = 0);
+    bool async_connect(const string& connection_string, void* event_handle, long timeout = 0);
 
     /// \brief Completes a previously initiated asynchronous connection operation.
     ///
@@ -1078,24 +1078,24 @@ public:
     /// \brief Returns name of the DBMS product.
     /// Returns the ODBC information type SQL_DBMS_NAME of the DBMS product
     /// accesssed by the driver via the current connection.
-    string_type dbms_name() const;
+    string dbms_name() const;
 
     /// \brief Returns version of the DBMS product.
     /// Returns the ODBC information type SQL_DBMS_VER of the DBMS product
     /// accesssed by the driver via the current connection.
-    string_type dbms_version() const;
+    string dbms_version() const;
 
     /// \brief Returns the name of the ODBC driver.
     /// \throws database_error
-    string_type driver_name() const;
+    string driver_name() const;
 
     /// \brief Returns the name of the currently connected database.
     /// Returns the current SQL_DATABASE_NAME information value associated with the connection.
-    string_type database_name() const;
+    string database_name() const;
 
     /// \brief Returns the name of the current catalog.
     /// Returns the current setting of the connection attribute SQL_ATTR_CURRENT_CATALOG.
-    string_type catalog_name() const;
+    string catalog_name() const;
 
 private:
     std::size_t ref_transaction();
@@ -1245,7 +1245,7 @@ public:
     /// \param result The column's value will be written to this parameter.
     /// \throws database_error, index_range_error, type_incompatible_error, null_access_error
     template <class T>
-    void get_ref(const string_type& column_name, T& result) const;
+    void get_ref(const string& column_name, T& result) const;
 
     /// \brief Gets data from the given column by name of the current rowset.
     ///
@@ -1256,7 +1256,7 @@ public:
     /// \param result The column's value will be written to this parameter.
     /// \throws database_error, index_range_error, type_incompatible_error
     template <class T>
-    void get_ref(const string_type& column_name, const T& fallback, T& result) const;
+    void get_ref(const string& column_name, const T& fallback, T& result) const;
 
     /// \brief Gets data from the given column of the current rowset.
     ///
@@ -1282,7 +1282,7 @@ public:
     /// \param column_name column's name.
     /// \throws database_error, index_range_error, type_incompatible_error, null_access_error
     template <class T>
-    T get(const string_type& column_name) const;
+    T get(const string& column_name) const;
 
     /// \brief Gets data from the given column by name of the current rowset.
     ///
@@ -1292,7 +1292,7 @@ public:
     /// \param fallback if value is null, return fallback instead.
     /// \throws database_error, index_range_error, type_incompatible_error
     template <class T>
-    T get(const string_type& column_name, const T& fallback) const;
+    T get(const string& column_name, const T& fallback) const;
 
     /// \brief Returns true if and only if the given column of the current rowset is null.
     ///
@@ -1314,21 +1314,21 @@ public:
     /// \see is_null()
     /// \param column_name column's name.
     /// \throws database_error, index_range_error
-    bool is_null(const string_type& column_name) const;
+    bool is_null(const string& column_name) const;
 
     /// \brief Returns the column number of the specified column name.
     ///
     /// Columns are numbered from left to right and 0-indexed.
     /// \param column_name column's name.
     /// \throws index_range_error
-    short column(const string_type& column_name) const;
+    short column(const string& column_name) const;
 
     /// \brief Returns the name of the specified column.
     ///
     /// Columns are numbered from left to right and 0-indexed.
     /// \param column position.
     /// \throws index_range_error
-    string_type column_name(short column) const;
+    string column_name(short column) const;
 
     /// \brief Returns the size of the specified column.
     ///
@@ -1338,7 +1338,7 @@ public:
     long column_size(short column) const;
 
     /// \brief Returns the size of the specified column by name.
-    long column_size(const string_type& column_name) const;
+    long column_size(const string& column_name) const;
 
     /// \brief Returns the number of decimal digits of the specified column.
     ///
@@ -1351,13 +1351,13 @@ public:
     int column_decimal_digits(short column) const;
 
     /// \brief Returns the number of decimal digits of the specified column by name.
-    int column_decimal_digits(const string_type& column_name) const;
+    int column_decimal_digits(const string& column_name) const;
 
     /// \brief Returns a identifying integer value representing the SQL type of this column.
     int column_datatype(short column) const;
 
     /// \brief Returns a identifying integer value representing the SQL type of this column by name.
-    int column_datatype(const string_type& column_name) const;
+    int column_datatype(const string& column_name) const;
 
     /// \brief Returns data source dependent data type name of this column.
     ///
@@ -1366,7 +1366,7 @@ public:
     /// If the type is unknown, an empty string is returned.
     /// \note Unlike other column metadata functions (eg. column_datatype()),
     /// this function cost is an extra ODBC API call.
-    string_type column_datatype_name(short column) const;
+    string column_datatype_name(short column) const;
 
     /// \brief Returns data source dependent data type name of this column by name.
     ///
@@ -1375,13 +1375,13 @@ public:
     /// If the type is unknown, an empty string is returned.
     /// \note Unlike other column metadata functions (eg. column_datatype()),
     /// this function cost is an extra ODBC API call.
-    string_type column_datatype_name(const string_type& column_name) const;
+    string column_datatype_name(const string& column_name) const;
 
     /// \brief Returns a identifying integer value representing the C type of this column.
     int column_c_datatype(short column) const;
 
     /// \brief Returns a identifying integer value representing the C type of this column by name.
-    int column_c_datatype(const string_type& column_name) const;
+    int column_c_datatype(const string& column_name) const;
 
     /// \brief Returns the next result, e.g. when stored procedure returns multiple result sets.
     bool next_result();
@@ -1517,11 +1517,11 @@ public:
     {
     public:
         bool next();                       ///< Move to the next result in the result set.
-        string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const;  ///< Fetch table schema.
-        string_type table_name() const;    ///< Fetch table name.
-        string_type table_type() const;    ///< Fetch table type.
-        string_type table_remarks() const; ///< Fetch table remarks.
+        string table_catalog() const; ///< Fetch table catalog.
+        string table_schema() const;  ///< Fetch table schema.
+        string table_name() const;    ///< Fetch table name.
+        string table_type() const;    ///< Fetch table type.
+        string table_remarks() const; ///< Fetch table remarks.
 
     private:
         friend class nanodbc::catalog;
@@ -1534,19 +1534,19 @@ public:
     {
     public:
         bool next();                           ///< Move to the next result in the result set.
-        string_type table_catalog() const;     ///< Fetch table catalog.
-        string_type table_schema() const;      ///< Fetch table schema.
-        string_type table_name() const;        ///< Fetch table name.
-        string_type column_name() const;       ///< Fetch column name.
+        string table_catalog() const;     ///< Fetch table catalog.
+        string table_schema() const;      ///< Fetch table schema.
+        string table_name() const;        ///< Fetch table name.
+        string column_name() const;       ///< Fetch column name.
         short data_type() const;               ///< Fetch column data type.
-        string_type type_name() const;         ///< Fetch column type name.
+        string type_name() const;         ///< Fetch column type name.
         long column_size() const;              ///< Fetch column size.
         long buffer_length() const;            ///< Fetch buffer length.
         short decimal_digits() const;          ///< Fetch decimal digits.
         short numeric_precision_radix() const; ///< Fetch numeric precission.
         short nullable() const;                ///< True iff column is nullable.
-        string_type remarks() const;           ///< Fetch column remarks.
-        string_type column_default() const;    ///< Fetch column's default.
+        string remarks() const;           ///< Fetch column remarks.
+        string column_default() const;    ///< Fetch column's default.
         short sql_data_type() const;           ///< Fetch column's SQL data type.
         short sql_datetime_subtype() const;    ///< Fetch datetime subtype of column.
         long char_octet_length() const;        ///< Fetch char octet length.
@@ -1561,7 +1561,7 @@ public:
         /// \note MSDN: This column returns a zero-length string if nullability is unknown.
         ///       ISO rules are followed to determine nullability.
         ///       An ISO SQL-compliant DBMS cannot return an empty string.
-        string_type is_nullable() const;
+        string is_nullable() const;
 
     private:
         friend class nanodbc::catalog;
@@ -1574,10 +1574,10 @@ public:
     {
     public:
         bool next();                       ///< Move to the next result in the result set.
-        string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const;  ///< Fetch table schema.
-        string_type table_name() const;    ///< Fetch table name.
-        string_type column_name() const;   ///< Fetch column name.
+        string table_catalog() const; ///< Fetch table catalog.
+        string table_schema() const;  ///< Fetch table schema.
+        string table_name() const;    ///< Fetch table name.
+        string column_name() const;   ///< Fetch column name.
 
         /// \brief Column sequence number in the key (starting with 1).
         /// Returns valye of KEY_SEQ column in result set returned by SQLPrimaryKeys.
@@ -1586,7 +1586,7 @@ public:
         /// \brief Primary key name.
         /// NULL if not applicable to the data source.
         /// Returns valye of PK_NAME column in result set returned by SQLPrimaryKeys.
-        string_type primary_key_name() const;
+        string primary_key_name() const;
 
     private:
         friend class nanodbc::catalog;
@@ -1599,14 +1599,14 @@ public:
     {
     public:
         bool next();                       ///< Move to the next result in the result set
-        string_type table_catalog() const; ///< Fetch table catalog.
-        string_type table_schema() const;  ///< Fetch table schema.
-        string_type table_name() const;    ///< Fetch table name.
-        string_type grantor() const;       ///< Fetch name of user who granted the privilege.
-        string_type grantee() const;       ///< Fetch name of user whom the privilege was granted.
-        string_type privilege() const;     ///< Fetch the table privilege.
+        string table_catalog() const; ///< Fetch table catalog.
+        string table_schema() const;  ///< Fetch table schema.
+        string table_name() const;    ///< Fetch table name.
+        string grantor() const;       ///< Fetch name of user who granted the privilege.
+        string grantee() const;       ///< Fetch name of user whom the privilege was granted.
+        string privilege() const;     ///< Fetch the table privilege.
         /// Fetch indicator whether the grantee is permitted to grant the privilege to other users.
-        string_type is_grantable() const;
+        string is_grantable() const;
 
     private:
         friend class nanodbc::catalog;
@@ -1627,10 +1627,10 @@ public:
     /// All arguments are treated as the Pattern Value Arguments.
     /// Empty string argument is equivalent to passing the search pattern '%'.
     catalog::tables find_tables(
-        const string_type& table = string_type(),
-        const string_type& type = string_type(),
-        const string_type& schema = string_type(),
-        const string_type& catalog = string_type());
+        const string& table = string(),
+        const string& type = string(),
+        const string& schema = string(),
+        const string& catalog = string());
 
     /// \brief Creates result set with tables and the privileges associated with each table.
     /// Tables information is obtained by executing `SQLTablePrivileges` function within
@@ -1646,9 +1646,9 @@ public:
     /// \note Due to the fact catalog cannot is not the Pattern Value Argument,
     ///       order of parameters is different than in the other catalog look-up functions.
     catalog::table_privileges find_table_privileges(
-        const string_type& catalog,
-        const string_type& table = string_type(),
-        const string_type& schema = string_type());
+        const string& catalog,
+        const string& table = string(),
+        const string& schema = string());
 
     /// \brief Creates result set with columns in one or more tables.
     ///
@@ -1660,10 +1660,10 @@ public:
     /// All arguments are treated as the Pattern Value Arguments.
     /// Empty string argument is equivalent to passing the search pattern '%'.
     catalog::columns find_columns(
-        const string_type& column = string_type(),
-        const string_type& table = string_type(),
-        const string_type& schema = string_type(),
-        const string_type& catalog = string_type());
+        const string& column = string(),
+        const string& table = string(),
+        const string& schema = string(),
+        const string& catalog = string());
 
     /// \brief Creates result set with columns that compose the primary key of a single table.
     ///
@@ -1674,19 +1674,19 @@ public:
     /// All arguments are treated as the Pattern Value Arguments.
     /// Empty string argument is equivalent to passing the search pattern '%'.
     catalog::primary_keys find_primary_keys(
-        const string_type& table,
-        const string_type& schema = string_type(),
-        const string_type& catalog = string_type());
+        const string& table,
+        const string& schema = string(),
+        const string& catalog = string());
 
     /// \brief Returns names of all catalogs (or databases) available in connected data source.
     ///
     /// Executes `SQLTable` function with `SQL_ALL_CATALOG` as catalog search pattern.
-    std::list<string_type> list_catalogs();
+    std::list<string> list_catalogs();
 
     /// \brief Returns names of all schemas available in connected data source.
     ///
     /// Executes `SQLTable` function with `SQL_ALL_SCHEMAS` as schema search pattern.
-    std::list<string_type> list_schemas();
+    std::list<string> list_schemas();
 
 private:
     connection conn_;
@@ -1717,11 +1717,11 @@ struct driver
     /// \brief Driver attributes.
     struct attribute
     {
-        nanodbc::string_type keyword; ///< Driver keyword attribute.
-        nanodbc::string_type value;   ///< Driver attribute value.
+        nanodbc::string keyword; ///< Driver keyword attribute.
+        nanodbc::string value;   ///< Driver attribute value.
     };
 
-    nanodbc::string_type name;       ///< Driver name.
+    nanodbc::string name;       ///< Driver name.
     std::list<attribute> attributes; ///< List of driver attributes.
 };
 
@@ -1740,7 +1740,7 @@ std::list<driver> list_drivers();
 ///            prevent auto commits from occurring after each individual operation is executed.
 /// \see open(), prepare(), execute(), result, transaction
 result
-execute(connection& conn, const string_type& query, long batch_operations = 1, long timeout = 0);
+execute(connection& conn, const string& query, long batch_operations = 1, long timeout = 0);
 
 /// \brief Opens, prepares, and executes query directly without creating result object.
 /// \param conn The connection where the statement will be executed.
@@ -1753,7 +1753,7 @@ execute(connection& conn, const string_type& query, long batch_operations = 1, l
 /// \see open(), prepare(), execute(), result, transaction
 void just_execute(
     connection& conn,
-    const string_type& query,
+    const string& query,
     long batch_operations = 1,
     long timeout = 0);
 
@@ -1805,7 +1805,7 @@ void just_transact(statement& stmt, long batch_operations);
 /// \param timeout The number in seconds before query timeout. Default is 0 indicating no timeout.
 /// \see open()
 /// \throws database_error, programming_error
-void prepare(statement& stmt, const string_type& query, long timeout = 0);
+void prepare(statement& stmt, const string& query, long timeout = 0);
 
 /// @}
 

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -35,7 +35,7 @@
 
 struct TestConfig
 {
-    nanodbc::string_type get_connection_string() const
+    nanodbc::string get_connection_string() const
     {
 #ifdef NANODBC_ENABLE_UNICODE
 #ifdef NANODBC_ENABLE_BOOST
@@ -48,7 +48,7 @@ struct TestConfig
         auto s = std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(
             connection_string_);
         auto p = reinterpret_cast<char16_t const*>(s.data());
-        return nanodbc::string_type(p, p + s.size());
+        return nanodbc::string(p, p + s.size());
 #else
         return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(
             connection_string_);
@@ -91,11 +91,11 @@ struct base_test_fixture
 
     // Utilities
 
-    nanodbc::string_type connection_string_;
+    nanodbc::string connection_string_;
 
     database_vendor vendor_ = database_vendor::unknown;
 
-    database_vendor get_vendor(nanodbc::string_type const& dbms)
+    database_vendor get_vendor(nanodbc::string const& dbms)
     {
         REQUIRE(!dbms.empty());
         if (contains_string(dbms, NANODBC_TEXT("Oracle")))
@@ -116,7 +116,7 @@ struct base_test_fixture
             return database_vendor::unknown;
     }
 
-    nanodbc::string_type get_binary_type_name()
+    nanodbc::string get_binary_type_name()
     {
         switch (vendor_)
         {
@@ -130,7 +130,7 @@ struct base_test_fixture
         }
     }
 
-    nanodbc::string_type get_text_type_name()
+    nanodbc::string get_text_type_name()
     {
         switch (vendor_)
         {
@@ -141,7 +141,7 @@ struct base_test_fixture
         }
     }
 
-    nanodbc::string_type get_primary_key_name(nanodbc::string_type const& assumed)
+    nanodbc::string get_primary_key_name(nanodbc::string const& assumed)
     {
         switch (vendor_)
         {
@@ -154,7 +154,7 @@ struct base_test_fixture
         }
     }
 
-    void check_data_type_size(nanodbc::string_type const& name, int column_size, short radix = -1)
+    void check_data_type_size(nanodbc::string const& name, int column_size, short radix = -1)
     {
         if (name == NANODBC_TEXT("float"))
         {
@@ -206,12 +206,12 @@ struct base_test_fixture
         return connection;
     }
 
-    nanodbc::string_type connection_string_parameter(nanodbc::string_type const& keyword)
+    nanodbc::string connection_string_parameter(nanodbc::string const& keyword)
     {
         // Find given keyword in the semi-colon-separated keyword=value pairs
         // of connection string and return its value, strippng `{` and `}` wrappers.
         if (connection_string_.empty())
-            return nanodbc::string_type();
+            return nanodbc::string();
 
         auto beg = connection_string_.begin();
         auto const end = connection_string_.end();
@@ -236,7 +236,7 @@ struct base_test_fixture
 
             beg = pair_end + 1;
         }
-        return nanodbc::string_type();
+        return nanodbc::string();
     }
 
     static void check_rows_equal(nanodbc::result results, int rows)
@@ -254,7 +254,7 @@ struct base_test_fixture
         return ss.str();
     }
 
-    nanodbc::string_type get_env(char const* var) const
+    nanodbc::string get_env(char const* var) const
     {
         char* env_value = nullptr;
         std::string value;
@@ -269,7 +269,7 @@ struct base_test_fixture
 #else
         env_value = std::getenv(var);
         if (!env_value)
-            return nanodbc::string_type();
+            return nanodbc::string();
         value = env_value;
 #endif
 
@@ -283,7 +283,7 @@ struct base_test_fixture
         auto s =
             std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(value);
         auto p = reinterpret_cast<char16_t const*>(s.data());
-        return nanodbc::string_type(p, p + s.size());
+        return nanodbc::string(p, p + s.size());
 #else
         return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(
             value);
@@ -293,22 +293,22 @@ struct base_test_fixture
 #endif
     }
 
-    bool contains_string(nanodbc::string_type const& str, nanodbc::string_type const& sub)
+    bool contains_string(nanodbc::string const& str, nanodbc::string const& sub)
     {
         if (str.empty() || sub.empty())
             return false;
 
-        return str.find(sub) != nanodbc::string_type::npos;
+        return str.find(sub) != nanodbc::string::npos;
     }
 
     bool iequals_string(
-        nanodbc::string_type const& lhs,
-        nanodbc::string_type const& rhs,
+        nanodbc::string const& lhs,
+        nanodbc::string const& rhs,
         std::locale const& loc = std::locale())
     {
         struct is_iequal
         {
-            using char_type = typename nanodbc::string_type::value_type;
+            using char_type = typename nanodbc::string::value_type;
 
             is_iequal(std::locale const& loc)
                 : loc_(loc)
@@ -341,8 +341,8 @@ struct base_test_fixture
     // `def` is a comma separated column definitions, trailing '(' and ')' are optional.
     void create_table(
         nanodbc::connection& connection,
-        nanodbc::string_type const& name,
-        nanodbc::string_type def) const
+        nanodbc::string const& name,
+        nanodbc::string def) const
     {
         if (def.front() != NANODBC_TEXT('('))
             def.insert(0, 1, NANODBC_TEXT('('));
@@ -350,7 +350,7 @@ struct base_test_fixture
         if (def.back() != NANODBC_TEXT(')'))
             def.push_back(NANODBC_TEXT(')'));
 
-        nanodbc::string_type sql(NANODBC_TEXT("CREATE TABLE "));
+        nanodbc::string sql(NANODBC_TEXT("CREATE TABLE "));
         sql += name;
         sql += NANODBC_TEXT(" ");
         sql += def;
@@ -360,7 +360,7 @@ struct base_test_fixture
         execute(connection, sql);
     }
 
-    virtual void drop_table(nanodbc::connection& connection, nanodbc::string_type const& name) const
+    virtual void drop_table(nanodbc::connection& connection, nanodbc::string const& name) const
     {
         bool table_exists = true;
         try

--- a/test/mssql_test.cpp
+++ b/test/mssql_test.cpp
@@ -146,7 +146,7 @@ TEST_CASE_METHOD(
     "test_blob_with_varchar",
     "[mssql][blob][binary][varbinary][varchar]")
 {
-    nanodbc::string_type s = NANODBC_TEXT(
+    nanodbc::string s = NANODBC_TEXT(
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
         "AAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
         "BBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
@@ -188,7 +188,7 @@ TEST_CASE_METHOD(
     nanodbc::result results =
         nanodbc::execute(connection, NANODBC_TEXT("select data from test_blob_with_varchar;"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(0) == s);
+    REQUIRE(results.get<nanodbc::string>(0) == s);
 }
 
 TEST_CASE_METHOD(
@@ -215,10 +215,10 @@ TEST_CASE_METHOD(
     nanodbc::result results = nanodbc::execute(
         conn, NANODBC_TEXT("select i, s from test_variable_string order by i;"), rowset_size);
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("this is a shorter text"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is a shorter text"));
     REQUIRE(results.next());
     REQUIRE(
-        results.get<nanodbc::string_type>(1) ==
+        results.get<nanodbc::string>(1) ==
         NANODBC_TEXT("this is a longer text of the two texts in the table"));
     REQUIRE(!results.next());
 }
@@ -244,11 +244,11 @@ TEST_CASE_METHOD(
     REQUIRE(results.next());
     REQUIRE(results.is_null(1));
     REQUIRE(
-        results.get<nanodbc::string_type>(1, NANODBC_TEXT("nothing")) == NANODBC_TEXT("nothing"));
+        results.get<nanodbc::string>(1, NANODBC_TEXT("nothing")) == NANODBC_TEXT("nothing"));
     REQUIRE(results.next());
     REQUIRE(!results.is_null(1));
     REQUIRE(
-        results.get<nanodbc::string_type>(1) ==
+        results.get<nanodbc::string>(1) ==
         NANODBC_TEXT("this is a longer text of the two texts in the table"));
     REQUIRE(!results.next());
 }
@@ -272,11 +272,11 @@ TEST_CASE_METHOD(
         conn, NANODBC_TEXT("select i, s from test_variable_string order by i;"), rowset_size);
     REQUIRE(results.next());
     REQUIRE(!results.is_null(1));
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("this is a shorter text"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("this is a shorter text"));
     REQUIRE(results.next());
     REQUIRE(results.is_null(1));
     REQUIRE(
-        results.get<nanodbc::string_type>(1, NANODBC_TEXT("nothing")) == NANODBC_TEXT("nothing"));
+        results.get<nanodbc::string>(1, NANODBC_TEXT("nothing")) == NANODBC_TEXT("nothing"));
     REQUIRE(!results.next());
 }
 
@@ -453,16 +453,16 @@ TEST_CASE_METHOD(mssql_fixture, "test_decimal", "[mssql][decimal]")
         auto result =
             execute(connection, NANODBC_TEXT("select d from test_decimal order by d asc;"));
         REQUIRE(result.next());
-        auto d = result.get<nanodbc::string_type>(0);
+        auto d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("-922337203685477.5808")); // Min value of SQL data type
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT(".0000"));
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("1.2300"));
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("922337203685477.5807")); // Max value of SQL data type MONEY
     }
 }
@@ -486,16 +486,16 @@ TEST_CASE_METHOD(mssql_fixture, "test_money", "[mssql][decimal][money]")
     {
         auto result = execute(connection, NANODBC_TEXT("select d from test_money order by d asc;"));
         REQUIRE(result.next());
-        auto d = result.get<nanodbc::string_type>(0);
+        auto d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("-922337203685477.5808")); // Min value of SQL data type MONEY
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT(".0000"));
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("1.2300"));
         REQUIRE(result.next());
-        d = result.get<nanodbc::string_type>(0);
+        d = result.get<nanodbc::string>(0);
         REQUIRE(d == NANODBC_TEXT("922337203685477.5807")); // Max value of SQL data type MONEY
     }
 }
@@ -678,11 +678,11 @@ TEST_CASE_METHOD(mssql_fixture, "test_bind_variant", "[mssql][variant]")
         {
             REQUIRE(result.get<std::int32_t>(0) == static_cast<std::int32_t>(v_i));
             REQUIRE(result.get<double>(1) == static_cast<double>(v_f));
-            REQUIRE(result.get<nanodbc::string_type>(2) == v_s.bstrVal);
+            REQUIRE(result.get<nanodbc::string>(2) == v_s.bstrVal);
             v_d.ChangeType(VT_BSTR);
             REQUIRE(
-                result.get<nanodbc::string_type>(3) ==
-                nanodbc::string_type(v_d.bstrVal).substr(0, 5));
+                result.get<nanodbc::string>(3) ==
+                nanodbc::string(v_d.bstrVal).substr(0, 5));
             REQUIRE(result.get<std::vector<std::uint8_t>>(4) == bytes);
             ++i;
         }

--- a/test/mysql_test.cpp
+++ b/test/mysql_test.cpp
@@ -60,7 +60,7 @@ TEST_CASE_METHOD(mysql_fixture, "test_affected_rows", "[mysql][affected_rows]")
     }
     // Inseting/retrieving long strings
     {
-        nanodbc::string_type long_string(1024, '\0');
+        nanodbc::string long_string(1024, '\0');
         for (unsigned i = 0; i < 1024; i++)
             long_string[i] = (i % 64) + 32;
 
@@ -78,7 +78,7 @@ TEST_CASE_METHOD(mysql_fixture, "test_affected_rows", "[mysql][affected_rows]")
 
         if (result.next())
         {
-            nanodbc::string_type str_from_db = result.get<nanodbc::string_type>(0);
+            nanodbc::string str_from_db = result.get<nanodbc::string>(0);
             REQUIRE(str_from_db == long_string);
         }
     }

--- a/test/postgresql_test.cpp
+++ b/test/postgresql_test.cpp
@@ -203,7 +203,7 @@ TEST_CASE_METHOD(postgresql_fixture, "test_time_with_time_zone", "[postgresql][t
         REQUIRE(result.next());
         // pgsqlODBC reports 'time with time zone' as SQL_WVARCHAR, not SQL_TIME.
         // See https://github.com/lexicalunit/nanodbc/pull/229
-        auto t = result.get<nanodbc::string_type>(0);
+        auto t = result.get<nanodbc::string>(0);
         REQUIRE(t == NANODBC_TEXT("13:45:12.345-08"));
     }
 }

--- a/test/sqlite_test.cpp
+++ b/test/sqlite_test.cpp
@@ -13,7 +13,7 @@ struct sqlite_fixture : public test_case_fixture
     {
         // According to the sqliteodbc documentation,
         // driver name is different on Windows and Unix.
-        nanodbc::string_type const driver_name =
+        nanodbc::string const driver_name =
 #ifdef _WIN32
             (NANODBC_TEXT("SQLite3 ODBC Driver"));
 #else
@@ -224,16 +224,16 @@ TEST_CASE_METHOD(sqlite_fixture, "test_decimal_conversion", "[sqlite][decimal][c
         execute(connection, NANODBC_TEXT("select * from test_decimal_conversion order by 1 desc;"));
 
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("12345.987"));
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("12345.987"));
 
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("5.6"));
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("5.6"));
 
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("1"));
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("1"));
 
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("-1.333"));
+    REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("-1.333"));
 }
 
 TEST_CASE_METHOD(sqlite_fixture, "test_exception", "[sqlite][exception]")
@@ -313,10 +313,10 @@ TEST_CASE_METHOD(sqlite_fixture, "test_integral_boundary", "[sqlite][integral]")
     // min
     REQUIRE(result.next());
     // All of string converted values are incorrect
-    // auto si1min = result.get<nanodbc::string_type>(0);
-    // auto si2min = result.get<nanodbc::string_type>(1);
-    // auto si4min = result.get<nanodbc::string_type>(2);
-    // auto si8min = result.get<nanodbc::string_type>(3);
+    // auto si1min = result.get<nanodbc::string>(0);
+    // auto si2min = result.get<nanodbc::string>(1);
+    // auto si4min = result.get<nanodbc::string>(2);
+    // auto si8min = result.get<nanodbc::string>(3);
     REQUIRE(result.get<std::int16_t>(0) == static_cast<std::int16_t>(i1min));
     REQUIRE(result.get<std::int16_t>(1) == i2min);
     REQUIRE(result.get<std::int32_t>(2) == i4min);
@@ -367,24 +367,24 @@ TEST_CASE_METHOD(sqlite_fixture, "test_integral_to_string_conversion", "[sqlite]
         NANODBC_TEXT("select * from test_integral_to_string_conversion order by i asc;"));
 
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("0"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("0"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("255"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("255"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-128"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("-128"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("127"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("127"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-32768"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("-32768"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("32767"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("32767"));
     REQUIRE(results.next());
     // FIXME: SQLite ODBC driver reports column size of 10 leading to truncation
     // "-214748364" == "-2147483648"
     // The driver bug?
-    // REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("-2147483648"));
+    // REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("-2147483648"));
     REQUIRE(results.next());
-    REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("2147483647"));
+    REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("2147483647"));
 }
 
 TEST_CASE_METHOD(sqlite_fixture, "test_move", "[sqlite][move]")

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -64,7 +64,7 @@ struct test_case_fixture : public base_test_fixture
         std::size_t const batch_size = 9;
         int integers[batch_size] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
         float floats[batch_size] = {1.123f, 2.345f, 3.1f, 4.5f, 5.678f, 6.f, 7.89f, 8.90f, 9.1234f};
-        nanodbc::string_type::value_type strings[batch_size][60] = {
+        nanodbc::string::value_type strings[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -84,7 +84,7 @@ struct test_case_fixture : public base_test_fixture
                 NANODBC_TEXT("test_batch_insert_mixed"),
                 NANODBC_TEXT("(i int, s varchar(60), f float)"));
 
-            nanodbc::string_type insert(NANODBC_TEXT("insert into test_batch_insert_mixed "));
+            nanodbc::string insert(NANODBC_TEXT("insert into test_batch_insert_mixed "));
             if (strings_param_pos == 2)
                 insert += NANODBC_TEXT("(i, f, s)");
             else if (strings_param_pos == 1)
@@ -126,7 +126,7 @@ struct test_case_fixture : public base_test_fixture
                     REQUIRE(
                         result.get<float>(1) ==
                         floats[i]); // exact test might fail, switch to Approx
-                    REQUIRE(result.get<nanodbc::string_type>(2) == strings[i]);
+                    REQUIRE(result.get<nanodbc::string>(2) == strings[i]);
                     ++i;
                 }
                 REQUIRE(i == batch_size);
@@ -137,7 +137,7 @@ struct test_case_fixture : public base_test_fixture
     template <std::size_t BatchSize, std::size_t MaxValueSize>
     void test_batch_insert_string_template(
         nanodbc::connection& conn,
-        nanodbc::string_type::value_type const (&strings)[BatchSize][MaxValueSize])
+        nanodbc::string::value_type const (&strings)[BatchSize][MaxValueSize])
     {
         create_table(
             conn, NANODBC_TEXT("test_batch_insert_string"), NANODBC_TEXT("(s varchar(60))"));
@@ -154,7 +154,7 @@ struct test_case_fixture : public base_test_fixture
             std::size_t i = 0;
             while (result.next())
             {
-                REQUIRE(result.get<nanodbc::string_type>(0) == strings[i]);
+                REQUIRE(result.get<nanodbc::string>(0) == strings[i]);
                 ++i;
             }
             REQUIRE(i == BatchSize);
@@ -167,7 +167,7 @@ struct test_case_fixture : public base_test_fixture
 
         // Test input buffer lengths smaller than and equal to column size (varchar(60)).
         std::size_t const batch_size = 5;
-        nanodbc::string_type::value_type strings25[batch_size][25] = {
+        nanodbc::string::value_type strings25[batch_size][25] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -175,7 +175,7 @@ struct test_case_fixture : public base_test_fixture
             NANODBC_TEXT("finally, the fifthstring")};
         test_batch_insert_string_template(conn, strings25);
 
-        nanodbc::string_type::value_type strings27[batch_size][27] = {
+        nanodbc::string::value_type strings27[batch_size][27] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -183,7 +183,7 @@ struct test_case_fixture : public base_test_fixture
             NANODBC_TEXT("finally, the fifthstring")};
         test_batch_insert_string_template(conn, strings27);
 
-        nanodbc::string_type::value_type strings30[batch_size][30] = {
+        nanodbc::string::value_type strings30[batch_size][30] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -191,7 +191,7 @@ struct test_case_fixture : public base_test_fixture
             NANODBC_TEXT("finally, the fifthstring")};
         test_batch_insert_string_template(conn, strings30);
 
-        nanodbc::string_type::value_type strings41[batch_size][41] = {
+        nanodbc::string::value_type strings41[batch_size][41] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -199,7 +199,7 @@ struct test_case_fixture : public base_test_fixture
             NANODBC_TEXT("finally, the fifthstring")};
         test_batch_insert_string_template(conn, strings41);
 
-        nanodbc::string_type::value_type strings55[batch_size][55] = {
+        nanodbc::string::value_type strings55[batch_size][55] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -207,7 +207,7 @@ struct test_case_fixture : public base_test_fixture
             NANODBC_TEXT("finally, the fifthstring")};
         test_batch_insert_string_template(conn, strings55);
 
-        nanodbc::string_type::value_type strings60[batch_size][60] = {
+        nanodbc::string::value_type strings60[batch_size][60] = {
             NANODBC_TEXT("first string"),
             NANODBC_TEXT("second string"),
             NANODBC_TEXT("third string"),
@@ -218,7 +218,7 @@ struct test_case_fixture : public base_test_fixture
 
     void test_blob()
     {
-        nanodbc::string_type s = NANODBC_TEXT(
+        nanodbc::string s = NANODBC_TEXT(
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
             "AAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
             "BBBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
@@ -258,14 +258,14 @@ struct test_case_fixture : public base_test_fixture
         nanodbc::result results =
             nanodbc::execute(connection, NANODBC_TEXT("select data from test_blob;"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == s);
+        REQUIRE(results.get<nanodbc::string>(0) == s);
     }
 
     void test_catalog_columns()
     {
         nanodbc::connection connection = connect();
         nanodbc::catalog catalog(connection);
-        nanodbc::string_type const dbms = connection.dbms_name();
+        nanodbc::string const dbms = connection.dbms_name();
         REQUIRE(!dbms.empty());
 
         // Check we can iterate over any columns
@@ -283,12 +283,12 @@ struct test_case_fixture : public base_test_fixture
 
         // Find a table with known name and verify its known columns
         {
-            nanodbc::string_type const binary_type_name = get_binary_type_name();
+            nanodbc::string const binary_type_name = get_binary_type_name();
             REQUIRE(!binary_type_name.empty());
-            nanodbc::string_type const text_type_name = get_text_type_name();
+            nanodbc::string const text_type_name = get_text_type_name();
             REQUIRE(!text_type_name.empty());
 
-            nanodbc::string_type const table_name(NANODBC_TEXT("test_catalog_columns"));
+            nanodbc::string const table_name(NANODBC_TEXT("test_catalog_columns"));
             drop_table(connection, table_name);
             execute(
                 connection,
@@ -501,12 +501,12 @@ struct test_case_fixture : public base_test_fixture
         nanodbc::connection connection = connect();
         nanodbc::catalog catalog(connection);
 
-        nanodbc::string_type const dbms = connection.dbms_name();
+        nanodbc::string const dbms = connection.dbms_name();
         REQUIRE(!dbms.empty());
 
         // Find a single-column primary key for table with known name
         {
-            nanodbc::string_type const table_name(NANODBC_TEXT("test_catalog_primary_keys_simple"));
+            nanodbc::string const table_name(NANODBC_TEXT("test_catalog_primary_keys_simple"));
             drop_table(connection, table_name);
             if (contains_string(dbms, NANODBC_TEXT("SQLite")))
             {
@@ -534,7 +534,7 @@ struct test_case_fixture : public base_test_fixture
 
         // Find a multi-column primary key for table with known name
         {
-            nanodbc::string_type const table_name(
+            nanodbc::string const table_name(
                 NANODBC_TEXT("test_catalog_primary_keys_composite"));
             drop_table(connection, table_name);
             execute(
@@ -586,7 +586,7 @@ struct test_case_fixture : public base_test_fixture
 
         // Check if there are any tables (with catalog restriction)
         {
-            nanodbc::string_type empty_name; // a placeholder, makes no restriction on the look-up
+            nanodbc::string empty_name; // a placeholder, makes no restriction on the look-up
             nanodbc::catalog::tables tables =
                 catalog.find_tables(empty_name, NANODBC_TEXT("TABLE"), empty_name, empty_name);
             long count = 0;
@@ -600,7 +600,7 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(count > 0);
         }
 
-        nanodbc::string_type const table_name(NANODBC_TEXT("test_catalog_tables"));
+        nanodbc::string const table_name(NANODBC_TEXT("test_catalog_tables"));
 
         // Find a table with known name
         {
@@ -640,7 +640,7 @@ struct test_case_fixture : public base_test_fixture
         {
             // Use SQLTables pattern search by name only (in any schema)
             {
-                nanodbc::string_type const view_name(NANODBC_TEXT("test_catalog_tables_view"));
+                nanodbc::string const view_name(NANODBC_TEXT("test_catalog_tables_view"));
                 try
                 {
                     execute(connection, NANODBC_TEXT("DROP VIEW ") + view_name);
@@ -669,10 +669,10 @@ struct test_case_fixture : public base_test_fixture
             // Use SQLTables pattern search by name inside given schema
             // TODO: Target other databases where INFORMATION_SCHEMA support is available.
             if (connection.dbms_name().find(NANODBC_TEXT("SQL Server")) !=
-                nanodbc::string_type::npos)
+                nanodbc::string::npos)
             {
-                nanodbc::string_type const view_name(NANODBC_TEXT("TABLE_PRIVILEGES"));
-                nanodbc::string_type const schema_name(NANODBC_TEXT("INFORMATION_SCHEMA"));
+                nanodbc::string const view_name(NANODBC_TEXT("TABLE_PRIVILEGES"));
+                nanodbc::string const schema_name(NANODBC_TEXT("INFORMATION_SCHEMA"));
                 nanodbc::catalog::tables tables =
                     catalog.find_tables(view_name, NANODBC_TEXT("VIEW"), schema_name);
                 // expect single record with the wanted table
@@ -714,7 +714,7 @@ struct test_case_fixture : public base_test_fixture
             auto tables = catalog.find_table_privileges(
                 NANODBC_TEXT(""), NANODBC_TEXT("test_catalog_table_privileges"));
             long count = 0;
-            std::set<nanodbc::string_type> privileges;
+            std::set<nanodbc::string> privileges;
             while (tables.next())
             {
                 // These two values must not be NULL (returned as empty string)
@@ -872,16 +872,16 @@ struct test_case_fixture : public base_test_fixture
             connection, NANODBC_TEXT("select * from test_decimal_conversion order by 1 desc;"));
 
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("12345.987"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("12345.987"));
 
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("5.600"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("5.600"));
 
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("1.000"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("1.000"));
 
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("-1.333"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("-1.333"));
     }
 
     void test_driver()
@@ -977,8 +977,8 @@ struct test_case_fixture : public base_test_fixture
         // A generic test to exercise the DBMS info API is callable.
         // DBMS-specific test (MySQL, SQLite, etc.) may perform extended checks.
         nanodbc::connection connection = connect();
-        REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_DRIVER_NAME).empty());
-        REQUIRE(!connection.get_info<nanodbc::string_type>(SQL_ODBC_VER).empty());
+        REQUIRE(!connection.get_info<nanodbc::string>(SQL_DRIVER_NAME).empty());
+        REQUIRE(!connection.get_info<nanodbc::string>(SQL_ODBC_VER).empty());
 
         // Test SQLUSMALLINT results
         REQUIRE(connection.get_info<unsigned short>(SQL_NON_NULLABLE_COLUMNS) == SQL_NNC_NON_NULL);
@@ -1202,7 +1202,7 @@ struct test_case_fixture : public base_test_fixture
             for (auto it = begin(results); it != end(results); ++it)
             {
                 REQUIRE(it->get<int>(0) > 0);
-                REQUIRE(it->get<nanodbc::string_type>(1).size() == 3);
+                REQUIRE(it->get<nanodbc::string>(1).size() == 3);
             }
             REQUIRE(
                 std::distance(begin(results), end(results)) ==
@@ -1216,7 +1216,7 @@ struct test_case_fixture : public base_test_fixture
             for (auto& row : results)
             {
                 REQUIRE(row.get<int>(0) > 0);
-                REQUIRE(row.get<nanodbc::string_type>(1).size() == 3);
+                REQUIRE(row.get<nanodbc::string>(1).size() == 3);
             }
             REQUIRE(
                 std::distance(begin(results), end(results)) ==
@@ -1280,12 +1280,12 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(results.get<int>(0, -1) == -1);
             REQUIRE(results.get<int>(NANODBC_TEXT("a"), -1) == -1);
             REQUIRE(
-                results.get<nanodbc::string_type>(0, NANODBC_TEXT("null")) == NANODBC_TEXT("null"));
+                results.get<nanodbc::string>(0, NANODBC_TEXT("null")) == NANODBC_TEXT("null"));
             REQUIRE(
-                results.get<nanodbc::string_type>(NANODBC_TEXT("a"), NANODBC_TEXT("null")) ==
+                results.get<nanodbc::string>(NANODBC_TEXT("a"), NANODBC_TEXT("null")) ==
                 NANODBC_TEXT("null"));
-            REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("z"));
-            REQUIRE(results.get<nanodbc::string_type>(NANODBC_TEXT("b")) == NANODBC_TEXT("z"));
+            REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("z"));
+            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("z"));
 
             int ref_int;
             results.get_ref(0, -1, ref_int);
@@ -1293,10 +1293,10 @@ struct test_case_fixture : public base_test_fixture
             results.get_ref(NANODBC_TEXT("a"), -2, ref_int);
             REQUIRE(ref_int == -2);
 
-            nanodbc::string_type ref_str;
-            results.get_ref<nanodbc::string_type>(0, NANODBC_TEXT("null"), ref_str);
+            nanodbc::string ref_str;
+            results.get_ref<nanodbc::string>(0, NANODBC_TEXT("null"), ref_str);
             REQUIRE(ref_str == NANODBC_TEXT("null"));
-            results.get_ref<nanodbc::string_type>(
+            results.get_ref<nanodbc::string>(
                 NANODBC_TEXT("a"), NANODBC_TEXT("null2"), ref_str);
             REQUIRE(ref_str == NANODBC_TEXT("null2"));
 
@@ -1306,8 +1306,8 @@ struct test_case_fixture : public base_test_fixture
             // .....................................................................................
             REQUIRE(results.get<int>(0) == 1);
             REQUIRE(results.get<int>(NANODBC_TEXT("a")) == 1);
-            REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("one"));
-            REQUIRE(results.get<nanodbc::string_type>(NANODBC_TEXT("b")) == NANODBC_TEXT("one"));
+            REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("one"));
+            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("one"));
 
             nanodbc::result results_copy = results;
 
@@ -1317,9 +1317,9 @@ struct test_case_fixture : public base_test_fixture
             // .....................................................................................
             REQUIRE(results_copy.get<int>(0, -1) == 2);
             REQUIRE(results_copy.get<int>(NANODBC_TEXT("a"), -1) == 2);
-            REQUIRE(results_copy.get<nanodbc::string_type>(1) == NANODBC_TEXT("two"));
+            REQUIRE(results_copy.get<nanodbc::string>(1) == NANODBC_TEXT("two"));
             REQUIRE(
-                results_copy.get<nanodbc::string_type>(NANODBC_TEXT("b")) == NANODBC_TEXT("two"));
+                results_copy.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("two"));
 
             // FIXME: not supported by the default SQL_CURSOR_FORWARD_ONLY
             // and will require SQL_ATTR_CURSOR_TYPE set to SQL_CURSOR_STATIC at least.
@@ -1331,10 +1331,10 @@ struct test_case_fixture : public base_test_fixture
             REQUIRE(results.next());
             // row = 3|tri
             // .....................................................................................
-            REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("3"));
-            REQUIRE(results.get<nanodbc::string_type>(NANODBC_TEXT("a")) == NANODBC_TEXT("3"));
-            REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("tri"));
-            REQUIRE(results.get<nanodbc::string_type>(NANODBC_TEXT("b")) == NANODBC_TEXT("tri"));
+            REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("3"));
+            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("a")) == NANODBC_TEXT("3"));
+            REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("tri"));
+            REQUIRE(results.get<nanodbc::string>(NANODBC_TEXT("b")) == NANODBC_TEXT("tri"));
 
             REQUIRE(!results.next());
             REQUIRE(results.at_end());
@@ -1354,7 +1354,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(connection.native_env_handle() != nullptr);
         REQUIRE(connection.transactions() == std::size_t(0));
 
-        const nanodbc::string_type name = NANODBC_TEXT("Fred");
+        const nanodbc::string name = NANODBC_TEXT("Fred");
 
         drop_table(connection, NANODBC_TEXT("test_string"));
         execute(connection, NANODBC_TEXT("create table test_string (s varchar(10));"));
@@ -1367,9 +1367,9 @@ struct test_case_fixture : public base_test_fixture
 
         nanodbc::result results = execute(connection, NANODBC_TEXT("select s from test_string;"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("Fred"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("Fred"));
 
-        nanodbc::string_type ref;
+        nanodbc::string ref;
         results.get_ref(0, ref);
         REQUIRE(ref == name);
     }
@@ -1381,11 +1381,11 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(connection.native_env_handle() != nullptr);
         REQUIRE(connection.transactions() == std::size_t(0));
 
-        const std::vector<nanodbc::string_type> first_name = {
+        const std::vector<nanodbc::string> first_name = {
             NANODBC_TEXT("Fred"), NANODBC_TEXT("Barney"), NANODBC_TEXT("Dino")};
-        const std::vector<nanodbc::string_type> last_name = {
+        const std::vector<nanodbc::string> last_name = {
             NANODBC_TEXT("Flintstone"), NANODBC_TEXT("Rubble"), NANODBC_TEXT("")};
-        const std::vector<nanodbc::string_type> gender = {
+        const std::vector<nanodbc::string> gender = {
             NANODBC_TEXT("Male"), NANODBC_TEXT("Male"), NANODBC_TEXT("")};
 
         drop_table(connection, NANODBC_TEXT("test_string_vector"));
@@ -1415,15 +1415,15 @@ struct test_case_fixture : public base_test_fixture
         nanodbc::result results =
             execute(connection, NANODBC_TEXT("select first,last,gender from test_string_vector"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("Fred"));
-        REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("Flintstone"));
-        REQUIRE(results.get<nanodbc::string_type>(2) == NANODBC_TEXT("Male"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("Fred"));
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("Flintstone"));
+        REQUIRE(results.get<nanodbc::string>(2) == NANODBC_TEXT("Male"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("Barney"));
-        REQUIRE(results.get<nanodbc::string_type>(1) == NANODBC_TEXT("Rubble"));
-        REQUIRE(results.get<nanodbc::string_type>(2) == NANODBC_TEXT("Male"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("Barney"));
+        REQUIRE(results.get<nanodbc::string>(1) == NANODBC_TEXT("Rubble"));
+        REQUIRE(results.get<nanodbc::string>(2) == NANODBC_TEXT("Male"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("Dino"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("Dino"));
         REQUIRE(results.is_null(1));
         REQUIRE(results.is_null(2));
     }
@@ -1435,7 +1435,7 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(connection.native_env_handle() != nullptr);
         REQUIRE(connection.transactions() == std::size_t(0));
 
-        const std::vector<nanodbc::string_type> name = {NANODBC_TEXT("foo"), NANODBC_TEXT("bar")};
+        const std::vector<nanodbc::string> name = {NANODBC_TEXT("foo"), NANODBC_TEXT("bar")};
 
         drop_table(connection, NANODBC_TEXT("test_string_vector_null_vector"));
         execute(
@@ -1457,9 +1457,9 @@ struct test_case_fixture : public base_test_fixture
         nanodbc::result results =
             execute(connection, NANODBC_TEXT("select name from test_string_vector_null_vector"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("foo"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("foo"));
         REQUIRE(results.next());
-        REQUIRE(results.get<nanodbc::string_type>(0) == NANODBC_TEXT("bar"));
+        REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("bar"));
         REQUIRE(results.next());
         REQUIRE(results.is_null(0));
     }
@@ -1476,11 +1476,11 @@ struct test_case_fixture : public base_test_fixture
             {0x00, 0x01, 0x02, 0x03}, {0x03, 0x02, 0x01, 0x00}};
 
         drop_table(connection, NANODBC_TEXT("test_batch_binary"));
-        nanodbc::string_type const binary_type_name = get_binary_type_name();
+        nanodbc::string const binary_type_name = get_binary_type_name();
 
         // PostgreSQL does not allow limits on bytea fields, MS-SQL requires
         // them on varbinary fields
-        nanodbc::string_type create_table_sql = NANODBC_TEXT("create table test_batch_binary (s ");
+        nanodbc::string create_table_sql = NANODBC_TEXT("create table test_batch_binary (s ");
         if (vendor_ == database_vendor::postgresql)
         {
             create_table_sql = create_table_sql + binary_type_name + NANODBC_TEXT(")");
@@ -1552,7 +1552,7 @@ struct test_case_fixture : public base_test_fixture
         statement.bind(0, data, elements);
         execute(statement, elements);
 
-        static const nanodbc::string_type::value_type* query =
+        static const nanodbc::string::value_type* query =
             NANODBC_TEXT("select count(1) from test_transaction;");
 
         check_rows_equal(execute(connection, query), 10);


### PR DESCRIPTION
`string_type` name resembles more of a trait member, while intention is more like namespace `nanodbc { class string; }`

Closes #257