### PR TITLE
Got rid of boost::locale dependency on GCC 4

### DIFF
--- a/example/example_unicode_utils.h
+++ b/example/example_unicode_utils.h
@@ -4,9 +4,9 @@
 #include <nanodbc/nanodbc.h>
 
 #if defined(__GNUC__) && __GNUC__ < 5
-#   include <cwchar>
+#include <cwchar>
 #else
-#   include <codecvt>
+#include <codecvt>
 #endif
 #include <locale>
 #include <string>

--- a/example/rowset_iteration.cpp
+++ b/example/rowset_iteration.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <array>
-#include <codecvt>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>

--- a/example/table_schema.cpp
+++ b/example/table_schema.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <array>
-#include <codecvt>
 #include <cstring>
 #include <iomanip>
 #include <iostream>

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <clocale>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <iomanip>

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -36,12 +36,12 @@
 #endif
 
 #ifdef NANODBC_ENABLE_BOOST
-#   include <boost/locale/encoding_utf.hpp>
+#include <boost/locale/encoding_utf.hpp>
 #elif defined(__GNUC__) && __GNUC__ < 5
-#   define NANODBC_USE_STDLIB
-#   include <cwchar>
+#define NANODBC_USE_STDLIB
+#include <cwchar>
 #else
-#   include <codecvt>
+#include <codecvt>
 #endif
 
 #ifdef __APPLE__

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -263,9 +263,7 @@ inline void convert(const wide_string& in, std::string& out)
     using boost::locale::conv::utf_to_utf;
     out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
 #elif defined(__GNUC__) && (__GNUC__ < 5)
-    std::vector<wchar_t> characters(in.length());
-    for (size_t i=0; i<in.length(); i++)
-        characters[i] = in[i];
+    std::vector<wchar_t> characters(in.begin(), in.end());
     const wchar_t * source = characters.data();
     size_t size = wcsnrtombs(nullptr, &source, characters.size(), 0, nullptr);
     if (size == std::string::npos)
@@ -296,9 +294,7 @@ inline void convert(const std::string& in, wide_string& out)
     std::vector<wchar_t> characters(size);
     const char * source = in.data();
     mbsnrtowcs(&characters[0], &source, in.length(), characters.size(), nullptr);
-    out.resize(size);
-    for (size_t i=0; i<in.length(); i++)
-        out[i] = characters[i];
+    out = std::string(characters.begin(), characters.end());
 #elif defined(_MSC_VER) && (_MSC_VER >= 1900)
     // Workaround for confirmed bug in VS2015 and VS2017 too
     // See: https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302

--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -37,8 +37,7 @@
 
 #ifdef NANODBC_ENABLE_BOOST
 #include <boost/locale/encoding_utf.hpp>
-#elif defined(__GNUC__) && __GNUC__ < 5
-#define NANODBC_USE_STDLIB
+#elif defined(__GNUC__) && (__GNUC__ < 5)
 #include <cwchar>
 #else
 #include <codecvt>
@@ -263,7 +262,7 @@ inline void convert(const wide_string& in, std::string& out)
 #ifdef NANODBC_ENABLE_BOOST
     using boost::locale::conv::utf_to_utf;
     out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
-#elif defined(NANODBC_USE_STDLIB)
+#elif defined(__GNUC__) && (__GNUC__ < 5)
     std::vector<wchar_t> characters(in.length());
     for (size_t i=0; i<in.length(); i++)
         characters[i] = in[i];
@@ -290,7 +289,7 @@ inline void convert(const std::string& in, wide_string& out)
 #ifdef NANODBC_ENABLE_BOOST
     using boost::locale::conv::utf_to_utf;
     out = utf_to_utf<wide_char_t>(in.c_str(), in.c_str() + in.size());
-#elif defined(NANODBC_USE_STDLIB)
+#elif defined(__GNUC__) && (__GNUC__ < 5)
     size_t size = mbsnrtowcs(nullptr, in.data(), in.length(), 0, nullptr);
     if (size == std::string::npos)
         throw std::range_error("UTF-8 -> UTF-16 conversion error");

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -18,11 +18,11 @@
 #endif
 
 #ifdef NANODBC_ENABLE_BOOST
-#   include <boost/locale/encoding_utf.hpp>
+#include <boost/locale/encoding_utf.hpp>
 #elif defined(__GNUC__) && __GNUC__ < 5
-#   include <cstdlib>
+#include <cstdlib>
 #else
-#   include <codecvt>
+#include <codecvt>
 #endif
 
 #ifdef _WIN32

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -18,9 +18,11 @@
 #endif
 
 #ifdef NANODBC_ENABLE_BOOST
-#include <boost/locale/encoding_utf.hpp>
+#   include <boost/locale/encoding_utf.hpp>
+#elif defined(__GNUC__) && __GNUC__ < 5
+#   include <cstdlib>
 #else
-#include <codecvt>
+#   include <codecvt>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This commit makes using boost for UTF-8 → UTF-16 and UTF-16 → UTF-8 conversion no longer needed. Standard C functions are used to do this.
Links: #59, #44.