### PR TITLE
SAP/sybase ASE odbc driver doesn't set sqlsize to 0 when retrieving varchar columns

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2575,8 +2575,8 @@ private:
 
         RETCODE rc;
         NANODBC_SQLCHAR column_name[1024];
-        SQLSMALLINT sqltype, scale, nullable, len;
-        SQLULEN sqlsize;
+        SQLSMALLINT sqltype = 0, scale = 0, nullable = 0, len = 0;
+        SQLULEN sqlsize = 0;
 
 #if defined(NANODBC_DO_ASYNC_IMPL)
         stmt_.disable_async();


### PR DESCRIPTION
The SAP Adaptive Server Enterprise odbc driver seems not to touch the sqlsize parameter at all, when calling SQLDescribeCol on a varchar column. Which results in undefined behavior as the variable is never initialized (this only results in a problem when compiled with -O2 for me, so that was fun to debug).