### PR TITLE
Fix handful of cppcheck warnings

### DIFF
--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1424,7 +1424,7 @@ public:
     result_iterator() = default;
 
     /// Create result iterator for a given result set.
-    result_iterator(result& r)
+    explicit result_iterator(result& r)
         : result_(r)
     {
         ++(*this);
@@ -1624,7 +1624,7 @@ public:
     };
 
     /// \brief Creates catalog operating on database accessible through the specified connection.
-    catalog(connection& conn);
+    explicit catalog(connection& conn);
 
     /// \brief Creates result set with catalogs, schemas, tables, or table types.
     ///

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -312,7 +312,7 @@ struct base_test_fixture
         {
             using char_type = typename nanodbc::string::value_type;
 
-            is_iequal(std::locale const& loc)
+            explicit is_iequal(std::locale const& loc)
                 : loc_(loc)
             {
             }


### PR DESCRIPTION
Command:
```
  cppcheck --template "{file}({line}): {severity} ({id}): {message}" \
    --enable=style --force --std=c++11 -j 8 -I nanodbc . 2> cppcheck.txt
```

Result:
* Class 'result_iterator' has a constructor with 1 argument that is not explicit.
* Class 'catalog' has a constructor with 1 argument that is not explicit.
* Struct 'is_iequal' has a constructor with 1 argument that is not explicit.