### PR TITLE
Extend Dockerfile to complete multi-container Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,59 @@
-FROM ubuntu:latest
+FROM ubuntu:17.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qy update \
- && DEBIAN_FRONTEND=noninteractive apt-get -qy install software-properties-common
+# NOTE: install apt-utils since it is Priority: important, should really be installed otherwise
+#       'debconf: delaying package configuration, since apt-utils is not installed'
+RUN apt-get -qy update && apt-get -qy install --no-upgrade --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        curl \
+        software-properties-common
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys BA9EF27F
-RUN DEBIAN_FRONTEND=noninteractive add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qy update \
- && DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-        $(apt-cache -q search "libboost-locale1\..*-dev" | awk '{print $1}' | sort -nr | head -n 1) \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN add-apt-repository "$(curl -s https://packages.microsoft.com/config/ubuntu/16.04/prod.list)"
+
+RUN apt-get -qy update && apt-get -qy install --no-upgrade --no-install-recommends \
         cmake \
-        doxygen \
         g++-5 \
         git \
+        iputils-ping \
         make \
         mysql-client \
-        mysql-server \
+        libsqliteodbc \
+        odbc-postgresql \
+        postgresql-client \
         sqlite3 \
         unixodbc \
         unixodbc-dev \
         vim
 
-# Might not be available, but install it if it is.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install jekyll || true
+RUN ACCEPT_EULA=Y apt-get -qy install --no-upgrade --no-install-recommends \
+        msodbcsql \
+        mssql-tools
 
-# NOTE: `libmyodbc`, the package for MySQL ODBC support, is no longer available directly via a
-# simple `apt-get install libmyodbc` command. Instead, you must install it manually. The following
-# blog post provides step-by-step instructions.
-# https://www.datasunrise.com/blog/how-to-install-the-mysql-odbc-driver-on-ubuntu-16-04/
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+
+# install reasonable locales (in fact, required by mssql-tools (sqlcmd))
+RUN apt-get install -y locales \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen
 
 RUN odbcinst -i -d -f /usr/share/sqliteodbc/unixodbc.ini
+
+# NOTE: `libmyodbc`, the package for MySQL ODBC support, is no longer available directly via a
+#       simple `apt-get install libmyodbc` command. Instead, you must install it manually.
+#       The following blog post provides step-by-step instructions, also used below
+#       https://www.datasunrise.com/blog/how-to-install-the-mysql-odbc-driver-on-ubuntu-16-04/
+# NOTE: Ubuntu 16.04 ships buggy unixODBC 2.3.1, so this container uses docker image with Ubuntu 17.04+
+#       See related discussion at https://github.com/lexicalunit/nanodbc/issues/149
+RUN curl -SL https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit.tar.gz | tar -zxC /opt
+RUN cp /opt/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/lib/libmyodbc5* /usr/lib/x86_64-linux-gnu/odbc/
+RUN /opt/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/bin/myodbc-installer -d -a -n "MySQL ODBC 5.3 ANSI Driver" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/libmyodbc5a.so;"
+RUN /opt/mysql-connector-odbc-5.3.9-linux-ubuntu17.04-x86-64bit/bin/myodbc-installer -d -a -n "MySQL ODBC 5.3 Unicode Driver" -t "DRIVER=/usr/lib/x86_64-linux-gnu/odbc/libmyodbc5w.so;"
+
+RUN  git clone https://github.com/lexicalunit/nanodbc.git /opt/nanodbc && mkdir -p /opt/nanodbc/build
 
 ENV CXX g++-5

--- a/README.md
+++ b/README.md
@@ -183,16 +183,33 @@ Building documentation and gh-pages requires the use of [Doxygen][doxygen] and
 ## Quick Setup for Testing or Development Environments
 
 To get up and running with nanodbc as fast as possible consider using the provided
-[Dockerfile](Dockerfile) or [Vagrantfile](Vagrantfile). For example, to spin up a [docker][docker]
-container suitable for testing and development of nanodbc:
+[Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml) or [Vagrantfile](Vagrantfile).
+
+For example, to spin up a [docker][docker] container suitable for testing and development of nanodbc:
 
 ```shell
 $ cd /path/to/nanodbc
 $ docker build -t nanodbc .
-$ docker run -v "$(pwd)":"/opt/$(basename $(pwd))" -it nanodbc /bin/bash
-root@hash:/# mkdir -p /opt/nanodbc/build && cd /opt/nanodbc/build
-root@hash:/opt/nanodbc/build# cmake ..
-root@hash:/opt/nanodbc/build# make nanodbc
+
+# Use container local nanodbc repository
+$ docker run -it nanodbc /bin/bash
+root@hash:/# mkdir -p /opt/nanodbc/build && cd /opt/nanodbc-host/build
+
+# Alternatively, bind host repository as container volume
+$ docker run -v "$(pwd)":"/opt/$(basename $(pwd))-host" -it nanodbc /bin/bash
+root@hash:/# mkdir -p /opt/nanodbc-host/build && cd /opt/nanodbc-host/build
+
+root@hash:/opt/nanodbc-host/build# cmake ..
+root@hash:/opt/nanodbc-host/build# make nanodbc
+```
+
+Or, spin up the complete multi-container environment with database services:
+
+```shell
+$ cd /path/to/nanodbc
+$ docker-compose build
+$ docker-compose up -d
+$ docker exec -it nanodbc /bin/bash
 ```
 
 Or, to build and ssh into a [vagrant][vagrant] VM (using VirtualBox for example) use:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# nanodbc development and testing multi-container docker setup
+version: '3'
+services:
+  mysql:
+    image: mysql:5.7
+    container_name: nanomysql
+    restart: unless-stopped
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: &default_credential nanodbc
+      MYSQL_DATABASE: *default_credential
+      MYSQL_USER: *default_credential
+      MYSQL_PASSWORD: *default_credential
+  pgsql:
+    image: postgres:9-alpine
+    container_name: nanopgsql
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER:  *default_credential
+      POSTGRES_PASSWORD:  *default_credential
+      POSTGRES_DB:  *default_credential
+  mssql:
+    image: microsoft/mssql-server-linux
+    container_name: nanomssql
+    restart: unless-stopped
+    ports:
+      - "1433:1433"
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: Password12! # required, must meet requied password complexity
+  nanodbc:
+    build: .
+    container_name: nanodbc
+    stdin_open: true
+    tty: true
+    depends_on:
+      - pgsql
+      - mysql
+      - mssql
+    environment:
+      # Make client command line friendlier
+      MYSQL_HOST: mysql
+      USER: *default_credential
+      MYSQL_PWD: *default_credential
+      SQLCMDSERVER: mssql
+      SQLCMDUSER: *default_credential
+      SQLCMDPASSWORD: Password12!
+      PGHOST: pgsql
+      PGUSER: *default_credential
+      PGPASSWORD: *default_credential # required, psql no longer accepts passwords from command line
+      PGDATABASE: *default_credential


### PR DESCRIPTION
Use docker-compose to build:
* three database containers with one service per container: mysql, pgsql, mssql.
* main container with nanodbc development environment, ODBC drivers
  and command line database clients, for ultimate convenience.

Database containers are available from host.
User can development nanodbc in local environment and
test against database services runing inside containers.

---

Tested on Windows 10 with Docker For Windows:

```
D:\>docker --version
Docker version 17.06.2-ce, build cec0b72

D:\>docker-compose -version
docker-compose version 1.14.0, build c7bdf9e3
```