### PR TITLE
 Allow parameter binding and result::get of narrow string when Unicode support is enabled

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -2069,7 +2069,10 @@ bool statement::statement_impl::equals(const std::string& lhs, const std::string
 template <>
 bool statement::statement_impl::equals(const wide_string& lhs, const wide_string& rhs)
 {
-    // convert narrow strings, cause wcsncmp doesn't work on some machines
+    // e6059ff3a79062f83256b9d1d3c9c8368798781e
+    // Functions like `swprintf()`, `wcsftime()`, `wcsncmp()` can not be used
+    // with `u16string` types. Instead, prefers to narrow unicode string to
+    // work with them, and then widen them after work has been completed.
     std::string narrow_lhs;
     narrow_lhs.reserve(lhs.size());
     convert(lhs, narrow_lhs);
@@ -2700,7 +2703,7 @@ private:
             case SQL_CHAR:
             case SQL_VARCHAR:
             case SQL_NVARCHAR:
-                col.ctype_ = SQL_C_CHAR;
+                col.ctype_ = sql_ctype<std::string>::value;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLCHAR);
                 if (is_blob)
                 {
@@ -2710,7 +2713,7 @@ private:
                 break;
             case SQL_WCHAR:
             case SQL_WVARCHAR:
-                col.ctype_ = SQL_C_WCHAR;
+                col.ctype_ = sql_ctype<wide_string>::value;
                 col.clen_ = (col.sqlsize_ + 1) * sizeof(SQLWCHAR);
                 if (is_blob)
                 {
@@ -2719,7 +2722,7 @@ private:
                 }
                 break;
             case SQL_LONGVARCHAR:
-                col.ctype_ = SQL_C_CHAR;
+                col.ctype_ = sql_ctype<std::string>::value;
                 col.blob_ = true;
                 col.clen_ = 0;
                 break;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -354,16 +354,16 @@ struct timestamp
 template <typename T>
 using is_string = std::integral_constant<
     bool,
-    std::is_same<std::decay_t<T>, std::string>::value ||
-        std::is_same<std::decay_t<T>, wide_string>::value>;
+    std::is_same<typename std::decay<T>::type, std::string>::value ||
+        std::is_same<typename std::decay<T>::type, wide_string>::value>;
 
 /// \brief A type trait for testing if a type is a character compatible with the current nanodbc
 /// configuration
 template <typename T>
 using is_character = std::integral_constant<
     bool,
-    std::is_same<std::decay_t<T>, std::string::value_type>::value ||
-        std::is_same<std::decay_t<T>, wide_char_t>::value>;
+    std::is_same<typename std::decay<T>::type, std::string::value_type>::value ||
+        std::is_same<typename std::decay<T>::type, wide_char_t>::value>;
 
 template <typename T>
 using enable_if_string = typename std::enable_if<is_string<T>::value>::type;

--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -157,6 +157,18 @@ typedef std::string string;
 #define NANODBC_TEXT(s) s
 #endif
 
+#ifdef NANODBC_USE_IODBC_WIDE_STRINGS
+typedef std::u32string wide_string;
+#else
+#ifdef _MSC_VER
+typedef std::wstring wide_string;
+#else
+typedef std::u16string wide_string;
+#endif
+#endif
+
+typedef wide_string::value_type wide_char_t;
+
 #if defined(_WIN64)
 // LLP64 machine: Windows
 typedef std::int64_t null_type;
@@ -336,6 +348,28 @@ struct timestamp
     std::int16_t sec;   ///< Seconds after the minute.
     std::int32_t fract; ///< Fractional seconds.
 };
+
+/// \brief A type trait for testing if a type is a std::basic_string compatible with the current
+/// nanodbc configuration
+template <typename T>
+using is_string = std::integral_constant<
+    bool,
+    std::is_same<std::decay_t<T>, std::string>::value ||
+        std::is_same<std::decay_t<T>, wide_string>::value>;
+
+/// \brief A type trait for testing if a type is a character compatible with the current nanodbc
+/// configuration
+template <typename T>
+using is_character = std::integral_constant<
+    bool,
+    std::is_same<std::decay_t<T>, std::string::value_type>::value ||
+        std::is_same<std::decay_t<T>, wide_char_t>::value>;
+
+template <typename T>
+using enable_if_string = typename std::enable_if<is_string<T>::value>::type;
+
+template <typename T>
+using enable_if_character = typename std::enable_if<is_character<T>::value>::type;
 
 /// \}
 
@@ -822,9 +856,10 @@ public:
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <class T, typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const* values,
+        T const* values,
         std::size_t value_size,
         std::size_t batch_size,
         param_direction direction = PARAM_IN);
@@ -835,59 +870,71 @@ public:
     /// Longest string in the array determines maximum length of individual value.
     ///
     /// \see bind_strings
+    template <class T, typename = enable_if_string<T>>
     void bind_strings(
         short param_index,
-        std::vector<string> const& values,
+        std::vector<T> const& values,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
-    template <std::size_t BatchSize, std::size_t ValueSize>
+    template <
+        std::size_t BatchSize,
+        std::size_t ValueSize,
+        class T,
+        typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const (&values)[BatchSize][ValueSize],
+        T const (&values)[BatchSize][ValueSize],
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string::value_type const*>(values);
+        auto param_values = reinterpret_cast<T const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <class T, typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const* values,
+        T const* values,
         std::size_t value_size,
         std::size_t batch_size,
-        string::value_type const* null_sentry,
+        T const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <class T, typename = enable_if_string<T>>
     void bind_strings(
         short param_index,
-        std::vector<string> const& values,
-        string::value_type const* null_sentry,
+        std::vector<T> const& values,
+        typename T::value_type const* null_sentry,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
-    template <std::size_t BatchSize, std::size_t ValueSize>
+    template <
+        std::size_t BatchSize,
+        std::size_t ValueSize,
+        class T,
+        typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const (&values)[BatchSize][ValueSize],
-        string::value_type const* null_sentry,
+        T const (&values)[BatchSize][ValueSize],
+        T const* null_sentry,
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string::value_type const*>(values);
+        auto param_values = reinterpret_cast<T const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, null_sentry, direction);
     }
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <class T, typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const* values,
+        T const* values,
         std::size_t value_size,
         std::size_t batch_size,
         bool const* nulls,
@@ -895,22 +942,27 @@ public:
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
+    template <class T, typename = enable_if_string<T>>
     void bind_strings(
         short param_index,
-        std::vector<string> const& values,
+        std::vector<T> const& values,
         bool const* nulls,
         param_direction direction = PARAM_IN);
 
     /// \brief Binds multiple string values.
     /// \see bind_strings
-    template <std::size_t BatchSize, std::size_t ValueSize>
+    template <
+        std::size_t BatchSize,
+        std::size_t ValueSize,
+        class T,
+        typename = enable_if_character<T>>
     void bind_strings(
         short param_index,
-        string::value_type const (&values)[BatchSize][ValueSize],
+        T const (&values)[BatchSize][ValueSize],
         bool const* nulls,
         param_direction direction = PARAM_IN)
     {
-        auto param_values = reinterpret_cast<string::value_type const*>(values);
+        auto param_values = reinterpret_cast<T const*>(values);
         bind_strings(param_index, param_values, ValueSize, BatchSize, nulls, direction);
     }
 

--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <random>
 #include <tuple>
+#include <locale>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 // These versions of Visual C++ do not yet support noexcept or override.
@@ -49,7 +50,10 @@ inline nanodbc::string convert(std::string const& in)
         sizeof(nanodbc::string::value_type) > 1,
         "NANODBC_ENABLE_UNICODE mode requires wide string");
     nanodbc::string out;
-#if defined(__GNUC__) && __GNUC__ < 5
+#ifdef NANODBC_ENABLE_BOOST
+	using boost::locale::conv::utf_to_utf;
+	out = utf_to_utf<nanodbc::string::value_type>(in.c_str(), in.c_str() + in.size());
+#elif defined(__GNUC__) && __GNUC__ < 5
     std::vector<wchar_t> characters(in.length());
     for (size_t i = 0; i < in.length(); i++)
         characters[i] = in[i];
@@ -77,7 +81,10 @@ inline std::string convert(nanodbc::string const& in)
 {
     static_assert(sizeof(nanodbc::string::value_type) > 1, "string must be wide");
     std::string out;
-#if defined(__GNUC__) && __GNUC__ < 5
+#ifdef NANODBC_ENABLE_BOOST
+	using boost::locale::conv::utf_to_utf;
+	out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
+#elif defined(__GNUC__) && __GNUC__ < 5
     size_t size = mbsnrtowcs(nullptr, in.data(), in.length(), 0, nullptr);
     if (size == std::string::npos)
         throw std::range_error("UTF-8 -> UTF-16 conversion error");
@@ -330,22 +337,8 @@ struct base_test_fixture
             return nanodbc::string();
         value = env_value;
 #endif
-
 #ifdef NANODBC_ENABLE_UNICODE
-#ifdef NANODBC_ENABLE_BOOST
-        using boost::locale::conv::utf_to_utf;
-        return utf_to_utf<char16_t>(value.c_str(), value.c_str() + value.size());
-// Workaround for confirmed bug in VS2015 and VS2017 too
-// See: https://connect.microsoft.com/VisualStudio/Feedback/Details/1403302
-#elif defined(_MSC_VER) && (_MSC_VER >= 1900)
-        auto s =
-            std::wstring_convert<std::codecvt_utf8_utf16<int16_t>, int16_t>().from_bytes(value);
-        auto p = reinterpret_cast<char16_t const*>(s.data());
-        return nanodbc::string(p, p + s.size());
-#else
-        return std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>().from_bytes(
-            value);
-#endif
+		return nanodbc::test::convert(value);
 #else
         return value;
 #endif


### PR DESCRIPTION
I guess I have to explain this one a bit:
We are using utf8 in our database (or at least we assume utf8) but don't use the unicode api, which works somewhat fine as we are the only one writing/reading. The problem we encountered then was that the error messages and connection parameters (username password) are encoded in whatever the system uses as a default. So we enabled the nanodbc unicode support and while this solves the encoding problem we would have to change our internal data structures to be able to bind parameters and using get_ref (basically those which take a string by non-const reference). Every other function call is fine for us, because we can simply convert the arguments/return values.
I think it would make sense to always support string and wide_string for data types, regardless of the odbc-api used, the same way it is ok to use 64bit integers on a 32bit system.

So this pr makes the following changes:
- nanodbc::wide_string is now always defined in the header
- new type traits, to test if a type is a string or wide_string, char or wide_char_t
- statement::bind_strings now always allows string and wide_string as paremeter (this is realized with SFINAE and the new type traits), I know it is long planned to simplify the bind api, and with this it gets even more complex (sorry about that ;)) but I wanted to stay backwards compatible 
- bind allows string and wide_string
- specializations of result::get for string and wide_string
- convert from string to wide_string is now always possible (I hope this works for everyone)

There were also a bug in the convert function and in the the test fixtures under gcc. (If needed I can do another pull request only with these changes).
