### PR TITLE
NUMERIC and DECIMAL can now be retrieved using arithmetic types again

### DIFF
--- a/test/base_test_fixture.h
+++ b/test/base_test_fixture.h
@@ -35,6 +35,7 @@
 #endif
 #include <sql.h>
 #include <sqlext.h>
+#include <locale>
 
 namespace nanodbc
 {
@@ -51,8 +52,8 @@ inline nanodbc::string convert(std::string const& in)
         "NANODBC_ENABLE_UNICODE mode requires wide string");
     nanodbc::string out;
 #ifdef NANODBC_ENABLE_BOOST
-	using boost::locale::conv::utf_to_utf;
-	out = utf_to_utf<nanodbc::string::value_type>(in.c_str(), in.c_str() + in.size());
+    using boost::locale::conv::utf_to_utf;
+    out = utf_to_utf<nanodbc::string::value_type>(in.c_str(), in.c_str() + in.size());
 #elif defined(__GNUC__) && __GNUC__ < 5
     std::vector<wchar_t> characters(in.length());
     for (size_t i = 0; i < in.length(); i++)
@@ -82,8 +83,8 @@ inline std::string convert(nanodbc::string const& in)
     static_assert(sizeof(nanodbc::string::value_type) > 1, "string must be wide");
     std::string out;
 #ifdef NANODBC_ENABLE_BOOST
-	using boost::locale::conv::utf_to_utf;
-	out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
+    using boost::locale::conv::utf_to_utf;
+    out = utf_to_utf<char>(in.c_str(), in.c_str() + in.size());
 #elif defined(__GNUC__) && __GNUC__ < 5
     size_t size = mbsnrtowcs(nullptr, in.data(), in.length(), 0, nullptr);
     if (size == std::string::npos)

--- a/test/test_case_fixture.h
+++ b/test/test_case_fixture.h
@@ -877,6 +877,29 @@ struct test_case_fixture : public base_test_fixture
         REQUIRE(results.get<nanodbc::string>(0) == NANODBC_TEXT("-1.333"));
     }
 
+    template <class T>
+    void test_decimal_to_integral_conversion_template()
+    {
+        nanodbc::connection connection = connect();
+        nanodbc::result results;
+        drop_table(connection, NANODBC_TEXT("test_decimal_conversion"));
+        execute(
+            connection, NANODBC_TEXT("create table test_decimal_conversion (d decimal(9, 3));"));
+        execute(
+            connection, NANODBC_TEXT("insert into test_decimal_conversion values (12345.987);"));
+        execute(connection, NANODBC_TEXT("insert into test_decimal_conversion values (5.600);"));
+        execute(connection, NANODBC_TEXT("insert into test_decimal_conversion values (1.000);"));
+        results = execute(
+            connection, NANODBC_TEXT("select * from test_decimal_conversion order by 1 desc;"));
+
+        REQUIRE(results.next());
+        REQUIRE(results.get<T>(0) == static_cast<T>(12345.987));
+        REQUIRE(results.next());
+        REQUIRE(results.get<T>(0) == static_cast<T>(5.6));
+        REQUIRE(results.next());
+        REQUIRE(results.get<T>(0) == static_cast<T>(1.0));
+    }
+
     void test_driver()
     {
         auto const driver_name = connection_string_parameter(NANODBC_TEXT("DRIVER"));
@@ -1039,6 +1062,7 @@ struct test_case_fixture : public base_test_fixture
             Fixture fixture;
             using type = typename std::tuple_element<i, TypeList>::type;
             fixture.template test_integral_template<type>();
+            fixture.template test_decimal_to_integral_conversion_template<type>();
             foreach
                 <Fixture, TypeList, i - 1>::run();
         }
@@ -1052,6 +1076,7 @@ struct test_case_fixture : public base_test_fixture
             Fixture fixture;
             using type = typename std::tuple_element<0, TypeList>::type;
             fixture.template test_integral_template<type>();
+            fixture.template test_decimal_to_integral_conversion_template<type>();
         }
     };
 


### PR DESCRIPTION
In #238 the behavior of NUMERIC and DECIMAL was changed, so that nanodbc uses strings internally to retain precision. Which is great, but unfortunately the change was done such that a `get<int64_t>()` on a NUMERIC now casts the first char of the string representation to an int.

This PR tries to convert the string to wanted type using stringstream.